### PR TITLE
[Spring MVC] 최현영 미션 제출합니다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.0.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'

--- a/src/main/java/roomescape/common/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/common/LoginMemberArgumentResolver.java
@@ -8,20 +8,15 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import roomescape.member.AuthenticationMember;
-import roomescape.member.MemberService;
 import roomescape.util.CookieUtil;
-import roomescape.util.JwtUtil;
+import roomescape.util.JwtProvider;
 
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-    private MemberService memberService;
-    private JwtUtil jwtUtil;
-    private CookieUtil cookieUtil;
+    private JwtProvider jwtProvider;
 
-    public LoginMemberArgumentResolver(MemberService memberService, JwtUtil jwtUtil, CookieUtil cookieUtil) {
-        this.memberService = memberService;
-        this.cookieUtil = cookieUtil;
-        this.jwtUtil = jwtUtil;
+    public LoginMemberArgumentResolver(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
     }
 
     @Override
@@ -32,10 +27,10 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String token = cookieUtil.extractTokenFromCookie(request);
-        Long memberId = jwtUtil.getMemberId(token);
-        String name = jwtUtil.getName(token);
-        String role = jwtUtil.getRole(token);
+        String token = CookieUtil.extractTokenFromCookie(request);
+        Long memberId = jwtProvider.getMemberId(token);
+        String name = jwtProvider.getName(token);
+        String role = jwtProvider.getRole(token);
 
         return new AuthenticationMember(memberId, name, role);
     }

--- a/src/main/java/roomescape/common/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/common/LoginMemberArgumentResolver.java
@@ -1,0 +1,42 @@
+package roomescape.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import roomescape.member.AuthenticationMember;
+import roomescape.member.MemberService;
+import roomescape.util.CookieUtil;
+import roomescape.util.JwtUtil;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private MemberService memberService;
+    private JwtUtil jwtUtil;
+    private CookieUtil cookieUtil;
+
+    public LoginMemberArgumentResolver(MemberService memberService, JwtUtil jwtUtil, CookieUtil cookieUtil) {
+        this.memberService = memberService;
+        this.cookieUtil = cookieUtil;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(AuthenticationMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = cookieUtil.extractTokenFromCookie(request);
+        Long memberId = jwtUtil.getMemberId(token);
+        String name = jwtUtil.getName(token);
+        String role = jwtUtil.getRole(token);
+
+        return new AuthenticationMember(memberId, name, role);
+    }
+}

--- a/src/main/java/roomescape/common/RoleHandlerInterceptor.java
+++ b/src/main/java/roomescape/common/RoleHandlerInterceptor.java
@@ -6,21 +6,20 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import roomescape.util.CookieUtil;
-import roomescape.util.JwtUtil;
+import roomescape.util.JwtProvider;
 
 @Component
 public class RoleHandlerInterceptor implements HandlerInterceptor {
-    private CookieUtil cookieUtil;
-    private JwtUtil jwtUtil;
 
-    public RoleHandlerInterceptor(CookieUtil cookieUtil, JwtUtil jwtUtil) {
-        this.cookieUtil = cookieUtil;
-        this.jwtUtil = jwtUtil;
+    private JwtProvider jwtProvider;
+
+    public RoleHandlerInterceptor( JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
     }
 
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String token = cookieUtil.extractTokenFromCookie(request);
-        String role = jwtUtil.getRole(token);
+        String token = CookieUtil.extractTokenFromCookie(request);
+        String role = jwtProvider.getRole(token);
         if (!role.equals("ADMIN")) {
             response.setStatus(401);
             return false;

--- a/src/main/java/roomescape/common/RoleHandlerInterceptor.java
+++ b/src/main/java/roomescape/common/RoleHandlerInterceptor.java
@@ -1,0 +1,34 @@
+package roomescape.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import roomescape.util.CookieUtil;
+import roomescape.util.JwtUtil;
+
+@Component
+public class RoleHandlerInterceptor implements HandlerInterceptor {
+    private CookieUtil cookieUtil;
+    private JwtUtil jwtUtil;
+
+    public RoleHandlerInterceptor(CookieUtil cookieUtil, JwtUtil jwtUtil) {
+        this.cookieUtil = cookieUtil;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = cookieUtil.extractTokenFromCookie(request);
+        String role = jwtUtil.getRole(token);
+        if (!role.equals("ADMIN")) {
+            response.setStatus(401);
+            return false;
+        }
+
+        return true;
+    }
+
+
+
+}

--- a/src/main/java/roomescape/common/WebConfig.java
+++ b/src/main/java/roomescape/common/WebConfig.java
@@ -1,0 +1,34 @@
+package roomescape.common;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+
+    private RoleHandlerInterceptor roleHandlerInterceptor;
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(RoleHandlerInterceptor role, LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.roleHandlerInterceptor = role;
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(roleHandlerInterceptor)
+                .addPathPatterns("/admin/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginMemberArgumentResolver);
+    }
+
+
+}

--- a/src/main/java/roomescape/exception/CustomException.java
+++ b/src/main/java/roomescape/exception/CustomException.java
@@ -1,0 +1,8 @@
+package roomescape.exception;
+
+
+public class CustomException extends RuntimeException {
+    public CustomException() {
+        super();
+    }
+}

--- a/src/main/java/roomescape/exception/ExceptionAdvisor.java
+++ b/src/main/java/roomescape/exception/ExceptionAdvisor.java
@@ -1,0 +1,18 @@
+package roomescape.exception;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvisor {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> handleCustomException(CustomException exception) {
+        System.out.println("handleCustomException ::" +  exception.getMessage());
+
+        return ResponseEntity.badRequest().build();
+    }
+
+}

--- a/src/main/java/roomescape/member/AuthenticationMember.java
+++ b/src/main/java/roomescape/member/AuthenticationMember.java
@@ -1,0 +1,25 @@
+package roomescape.member;
+
+public class AuthenticationMember {
+    private Long id;
+    private String name;
+    private String role;
+
+    public AuthenticationMember(Long id, String name, String role) {
+        this.id = id;
+        this.name = name;
+        this.role = role;
+    }
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+}

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.util.CookieUtil;
 
 import java.net.URI;
 
@@ -15,13 +16,16 @@ import java.net.URI;
 public class MemberController {
     private MemberService memberService;
 
-    public MemberController(MemberService memberService) {
+    private CookieUtil cookieUtil;
+
+    public MemberController(MemberService memberService, CookieUtil cookieUtil) {
         this.memberService = memberService;
+        this.cookieUtil = cookieUtil;
     }
 
     @PostMapping("/members")
     public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
-        MemberResponse member = memberService.createMember(memberRequest);
+        MemberResponse.MemberInfoResponse member = memberService.createMember(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + member.getId())).body(member);
     }
 
@@ -33,5 +37,20 @@ public class MemberController {
         cookie.setMaxAge(0);
         response.addCookie(cookie);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
+        String token = memberService.login(memberRequest.getEmail(), memberRequest.getPassword());
+        Cookie cookie = cookieUtil.createCookie("token", token, true, "/", -1);
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity check(HttpServletRequest request) {
+
+        return ResponseEntity.ok().body(memberService.check(request));
     }
 }

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -16,11 +16,9 @@ import java.net.URI;
 public class MemberController {
     private MemberService memberService;
 
-    private CookieUtil cookieUtil;
 
-    public MemberController(MemberService memberService, CookieUtil cookieUtil) {
+    public MemberController(MemberService memberService) {
         this.memberService = memberService;
-        this.cookieUtil = cookieUtil;
     }
 
     @PostMapping("/members")
@@ -42,7 +40,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<Void> login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
         String token = memberService.login(memberRequest.getEmail(), memberRequest.getPassword());
-        Cookie cookie = cookieUtil.createCookie("token", token, true, "/", -1);
+        Cookie cookie = CookieUtil.createCookie(token, true, "/", -1);
         response.addCookie(cookie);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/roomescape/member/MemberResponse.java
+++ b/src/main/java/roomescape/member/MemberResponse.java
@@ -1,25 +1,46 @@
 package roomescape.member;
 
 public class MemberResponse {
-    private Long id;
-    private String name;
-    private String email;
 
-    public MemberResponse(Long id, String name, String email) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
+    public static class MemberInfoResponse{
+        private Long id;
+        private String name;
+        private String email;
+
+        public MemberInfoResponse(Long id, String name, String email) {
+            this.id = id;
+            this.name = name;
+            this.email = email;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
     }
 
-    public Long getId() {
-        return id;
-    }
+    public static class AuthorizationResponse{
+        private String name;
+        private String role;
 
-    public String getName() {
-        return name;
-    }
+        public AuthorizationResponse(String name, String role) {
+            this.name = name;
+            this.role = role;
+        }
 
-    public String getEmail() {
-        return email;
+        public String getName() {
+            return name;
+        }
+
+        public String getRole(){
+            return role;
+        }
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,24 +1,21 @@
 package roomescape.member;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import roomescape.util.CookieUtil;
-import roomescape.util.JwtUtil;
+import roomescape.util.JwtProvider;
 
 
 @Service
 public class MemberService {
     private MemberDao memberDao;
-    private JwtUtil jwtUtil;
 
-    private CookieUtil cookieUtil;
+    private JwtProvider jwtProvider;
 
 
-    public MemberService(MemberDao memberDao, JwtUtil jwtUtil, CookieUtil cookieUtil) {
+    public MemberService(MemberDao memberDao, JwtProvider jwtProvider) {
         this.memberDao = memberDao;
-        this.cookieUtil = cookieUtil;
-        this.jwtUtil = jwtUtil;
+        this.jwtProvider = jwtProvider;
     }
 
     public MemberResponse.MemberInfoResponse createMember(MemberRequest memberRequest) {
@@ -30,13 +27,13 @@ public class MemberService {
     public String login(String email, String password) {
         Member member = memberDao.findByEmailAndPassword(email, password);
 
-        return jwtUtil.createToken(member.getId(), member.getName(), member.getRole());
+        return jwtProvider.createToken(member.getId(), member.getName(), member.getRole());
     }
 
     public MemberResponse.AuthorizationResponse check(HttpServletRequest request) {
-        String token = cookieUtil.extractTokenFromCookie(request);
+        String token = CookieUtil.extractTokenFromCookie(request);
 
-        return new MemberResponse.AuthorizationResponse(jwtUtil.getName(token), jwtUtil.getRole(token));
+        return new MemberResponse.AuthorizationResponse(jwtProvider.getName(token), jwtProvider.getRole(token));
     }
 
 

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,17 +1,43 @@
 package roomescape.member;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
+import roomescape.util.CookieUtil;
+import roomescape.util.JwtUtil;
+
 
 @Service
 public class MemberService {
     private MemberDao memberDao;
+    private JwtUtil jwtUtil;
 
-    public MemberService(MemberDao memberDao) {
+    private CookieUtil cookieUtil;
+
+
+    public MemberService(MemberDao memberDao, JwtUtil jwtUtil, CookieUtil cookieUtil) {
         this.memberDao = memberDao;
+        this.cookieUtil = cookieUtil;
+        this.jwtUtil = jwtUtil;
     }
 
-    public MemberResponse createMember(MemberRequest memberRequest) {
+    public MemberResponse.MemberInfoResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
-        return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+
+        return new MemberResponse.MemberInfoResponse(member.getId(), member.getName(), member.getEmail());
     }
+
+    public String login(String email, String password) {
+        Member member = memberDao.findByEmailAndPassword(email, password);
+
+        return jwtUtil.createToken(member.getId(), member.getName(), member.getRole());
+    }
+
+    public MemberResponse.AuthorizationResponse check(HttpServletRequest request) {
+        String token = cookieUtil.extractTokenFromCookie(request);
+
+        return new MemberResponse.AuthorizationResponse(jwtUtil.getName(token), jwtUtil.getRole(token));
+    }
+
+
 }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.member.AuthenticationMember;
 
 import java.net.URI;
 import java.util.List;
@@ -26,14 +27,13 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, AuthenticationMember authenticationMember) {
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
         }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+        ReservationResponse reservation = reservationService.save(authenticationMember, reservationRequest);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -1,5 +1,6 @@
 package roomescape.reservation;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,7 +28,7 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, AuthenticationMember authenticationMember) {
+    public ResponseEntity create(@RequestBody @Valid ReservationRequest reservationRequest, AuthenticationMember authenticationMember) {
         if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -1,9 +1,15 @@
 package roomescape.reservation;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public class ReservationRequest {
     private String name;
+    @NotBlank
     private String date;
-    private Long theme;
+    @NotNull
+    private Long theme = 1L;
+    @NotNull
     private Long time;
 
     public String getName() {

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -21,4 +21,9 @@ public class ReservationRequest {
     public Long getTime() {
         return time;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package roomescape.reservation;
 
 import org.springframework.stereotype.Service;
+import roomescape.member.AuthenticationMember;
 
 import java.util.List;
 
@@ -12,10 +13,18 @@ public class ReservationService {
         this.reservationDao = reservationDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    public ReservationResponse save(AuthenticationMember authenticationMember, ReservationRequest reservationRequest) {
+        if(reservationRequest.getName() != null){
+            Reservation reservation = reservationDao.save(reservationRequest);
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+            return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        }
+        else{
+            reservationRequest.setName(authenticationMember.getName());
+            Reservation reservation = reservationDao.save(reservationRequest);
+
+            return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        }
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/util/CookieUtil.java
+++ b/src/main/java/roomescape/util/CookieUtil.java
@@ -1,0 +1,31 @@
+package roomescape.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class CookieUtil {
+
+    public String extractTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("token")) {
+                return cookie.getValue();
+            }
+        }
+
+        return "";
+    }
+
+
+    public Cookie createCookie(String name, String value, boolean httpOnly, String path, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setPath(path);
+        cookie.setMaxAge(maxAge);
+        return cookie;
+    }
+
+}

--- a/src/main/java/roomescape/util/CookieUtil.java
+++ b/src/main/java/roomescape/util/CookieUtil.java
@@ -5,10 +5,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 
-@Component
+
 public class CookieUtil {
 
-    public String extractTokenFromCookie(HttpServletRequest request) {
+    public static String extractTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals("token")) {
@@ -20,8 +20,8 @@ public class CookieUtil {
     }
 
 
-    public Cookie createCookie(String name, String value, boolean httpOnly, String path, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
+    public static Cookie createCookie( String value, boolean httpOnly, String path, int maxAge) {
+        Cookie cookie = new Cookie("token", value);
         cookie.setHttpOnly(httpOnly);
         cookie.setPath(path);
         cookie.setMaxAge(maxAge);

--- a/src/main/java/roomescape/util/JwtProvider.java
+++ b/src/main/java/roomescape/util/JwtProvider.java
@@ -1,6 +1,7 @@
 package roomescape.util;
 
 
+import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -9,9 +10,21 @@ import org.springframework.stereotype.Component;
 
 
 @Component
-public class JwtUtil {
+public class JwtProvider {
 
-    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+    private JwtParser jwtParser;
+    @Value("${roomescape.auth.jwt.secret}")
+    private String secretKey;
+
+    @PostConstruct
+    public void init(){
+        this.jwtParser = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build();
+    }
+
+
+
 
     public  String createToken(Long id, String name, String role) {
 
@@ -24,23 +37,17 @@ public class JwtUtil {
     }
 
     public String getName(String token) {
-         return Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
+         return jwtParser
                 .parseClaimsJws(token).getBody().get("name").toString();
     }
 
     public  String getRole(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
+        return jwtParser
                 .parseClaimsJws(token).getBody().get("role").toString();
     }
 
     public Long getMemberId(String token) {
-        return Long.parseLong(Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
+        return Long.parseLong(jwtParser
                 .parseClaimsJws(token).getBody().getSubject());
     }
 

--- a/src/main/java/roomescape/util/JwtUtil.java
+++ b/src/main/java/roomescape/util/JwtUtil.java
@@ -1,0 +1,50 @@
+package roomescape.util;
+
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class JwtUtil {
+
+    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+
+    public  String createToken(Long id, String name, String role) {
+
+        return Jwts.builder()
+                .setSubject(id.toString())
+                .claim("name", name)
+                .claim("role", role)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+    }
+
+    public String getName(String token) {
+         return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token).getBody().get("name").toString();
+    }
+
+    public  String getRole(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token).getBody().get("role").toString();
+    }
+
+    public Long getMemberId(String token) {
+        return Long.parseLong(Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token).getBody().getSubject());
+    }
+
+
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+roomescape.auth.jwt.secret="Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E="

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.reservation.ReservationResponse;
-import roomescape.util.CookieUtil;
-import roomescape.util.JwtUtil;
+import roomescape.util.JwtProvider;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,8 +52,8 @@ public class MissionStepTest {
 
     @Test
     void 이단계() {
-        JwtUtil jwtUtil = new JwtUtil();
-        String token = jwtUtil.createToken(1L, "어드민", "ADMIN");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+        JwtProvider jwtProvider = new JwtProvider();
+        String token = jwtProvider.createToken(1L, "어드민", "ADMIN");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
 
         Map<String, String> params = new HashMap<>();
         params.put("date", "2024-03-01");
@@ -88,9 +87,9 @@ public class MissionStepTest {
 
     @Test
     void 삼단계() {
-        JwtUtil jwtUtil = new JwtUtil();
-        String brownToken = jwtUtil.createToken(2L, "브라운", "USER");
-        String adminToken = jwtUtil.createToken(1L, "어드민", "ADMIN");
+        JwtProvider jwtProvider = new JwtProvider();
+        String brownToken = jwtProvider.createToken(2L, "브라운", "USER");
+        String adminToken = jwtProvider.createToken(1L, "어드민", "ADMIN");
 
         RestAssured.given().log().all()
                 .cookie("token", brownToken)

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -7,6 +7,9 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.ReservationResponse;
+import roomescape.util.CookieUtil;
+import roomescape.util.JwtUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,5 +37,71 @@ public class MissionStepTest {
         String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
 
         assertThat(token).isNotBlank();
+
+        ExtractableResponse<Response> checkResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/login/check")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        assertThat(checkResponse.body().jsonPath().getString("name")).isEqualTo("어드민");
+    }
+
+
+
+    @Test
+    void 이단계() {
+        JwtUtil jwtUtil = new JwtUtil();
+        String token = jwtUtil.createToken(1L, "어드민", "ADMIN");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+    }
+
+    @Test
+    void 삼단계() {
+        JwtUtil jwtUtil = new JwtUtil();
+        String brownToken = jwtUtil.createToken(2L, "브라운", "USER");
+        String adminToken = jwtUtil.createToken(1L, "어드민", "ADMIN");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
     }
 }


### PR DESCRIPTION
ArgumentResolver라는 객체를 처음 접해보며 세션 또는 쿠키의 값을 가공해서 파라미터로 정의된 객체에게 전달하는 것을 알게되었습니다. 
기능을 구현하면서 Jwt와 Cookie를 관리하는 Util 객체를 생성하여 처리하였습니다. 여기서 궁금한 사항은 기존의 자바의 내장 라이브러리들(Long.parseLong()과 같은) 은 Static 키워드를 통해서 객체를 생성하지 않고 전역 메서드을 호출하도록 구현되어 있습니다. Jwt와 Cookie를 가공하고 처리하는 로직이 담긴 유틸리티 클래스를 기존의 자바 라이브러리와 같이 전역으로 메서드를 정의하여 각 레이어에서 활용할 수 있도록 해야할지, 아니면 의존성 주입을 통해 메서드를 호출하는 식으로 진행해야하는지 판단이 되질 않습니다. 따라서 이런 유틸리티 클래스의 메서드는 전역으로 선언하여 호출되도록 하는지, 아니면 Component화 해서 필요한 스프링 빈에서 의존성 주입을 받아 호출되도록 해야는지 궁금합니다. 