### PR TITLE
chore: 유효하지 않은 ddl-auto 주석 코드 수정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.url=jdbc:h2:mem:database
 
 #spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true
-#spring.jpa.ddl-auto=create-drop
+#spring.jpa.hibernate.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
 #roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=


### PR DESCRIPTION
JPA 미션 진행 중 주석을 그대로 해제하고 미션을 진행하다가 어려움을 겪은 분이 계셔서, 잘못 작성되어 있는 ddl-auto 설정에 대한 주석 코드 수정이 필요해보였습니다.

따라서, `spring.jpa.ddl-auto=create-drop` 에서 `spring.jpa.hibernate.ddl-auto=create-drop` 으로 주석 코드를 변경하였습니다.