### PR TITLE
fix: time.html 내의 버튼 태그 문구 수정

### DIFF
--- a/src/main/resources/templates/admin/time.html
+++ b/src/main/resources/templates/admin/time.html
@@ -52,7 +52,7 @@
 <div class="content-container">
   <h2 class="content-container-title">시간 관리 페이지</h2>
   <div class="table-header">
-    <button id="add-button" class="btn btn-custom mb-2 float-right">예약 추가</button>
+    <button id="add-button" class="btn btn-custom mb-2 float-right">시간 추가</button>
   </div>
   <div class="table-container"/>
   <table class="table">


### PR DESCRIPTION
어드민 페이지 중, 시간 관리 페이지에서 시간을 추가하는 버튼의 문구를 `예약 추가` 에서 `시간 추가`로 수정하였습니다.