### PR TITLE
[Spring MVC] 김두현 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/global/auth/AuthResponse.java
+++ b/src/main/java/roomescape/global/auth/AuthResponse.java
@@ -1,0 +1,12 @@
+package roomescape.global.auth;
+
+import roomescape.member.Member;
+
+public record AuthResponse(
+    String name
+) {
+
+    public static AuthResponse from(Member member) {
+        return new AuthResponse(member.getName());
+    }
+}

--- a/src/main/java/roomescape/global/auth/AuthorizationInterceptor.java
+++ b/src/main/java/roomescape/global/auth/AuthorizationInterceptor.java
@@ -31,15 +31,15 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         Cookie[] cookies = request.getCookies();
         String token = cookieUtil.extractTokenFromCookie(cookies);
 
-        if (!token.isEmpty()) {
-            Member member = memberService.getAuth(token);
+        if(token.isEmpty()) return false;
 
-            if (member == null || !member.getRole().equals("ADMIN")) {
-                response.setStatus(401);
-                return false;
-            } else return true;
-        } else{
+        Member member = memberService.getAuth(token);
+
+        if (member == null || !member.getRole().equals("ADMIN")) {
+            response.setStatus(401);
             return false;
         }
+
+        return true;
     }
 }

--- a/src/main/java/roomescape/global/auth/AuthorizationInterceptor.java
+++ b/src/main/java/roomescape/global/auth/AuthorizationInterceptor.java
@@ -1,0 +1,45 @@
+package roomescape.global.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import roomescape.member.Member;
+import roomescape.member.MemberService;
+
+@Component
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+    private final MemberService memberService;
+    private final CookieUtil cookieUtil;
+
+    @Autowired
+    public AuthorizationInterceptor(MemberService memberService, CookieUtil cookieUtil) {
+        this.memberService = memberService;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws Exception {
+        Cookie[] cookies = request.getCookies();
+        String token = cookieUtil.extractTokenFromCookie(cookies);
+
+        if (!token.isEmpty()) {
+            Member member = memberService.getAuth(token);
+
+            if (member == null || !member.getRole().equals("ADMIN")) {
+                response.setStatus(401);
+                return false;
+            } else return true;
+        } else{
+            return false;
+        }
+    }
+}

--- a/src/main/java/roomescape/global/auth/CookieUtil.java
+++ b/src/main/java/roomescape/global/auth/CookieUtil.java
@@ -1,5 +1,7 @@
 package roomescape.global.auth;
 
+import java.util.Arrays;
+
 import org.springframework.stereotype.Component;
 
 import jakarta.servlet.http.Cookie;
@@ -16,12 +18,10 @@ public class CookieUtil {
     }
 
     public String extractTokenFromCookie(Cookie[] cookies) {
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("token")) {
-                return cookie.getValue();
-            }
-        }
-
-        return "";
+        return Arrays.stream(cookies)
+            .filter(cookie -> "token".equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findFirst()
+            .orElse("");
     }
 }

--- a/src/main/java/roomescape/global/auth/CookieUtil.java
+++ b/src/main/java/roomescape/global/auth/CookieUtil.java
@@ -1,0 +1,27 @@
+package roomescape.global.auth;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CookieUtil {
+    public void addCookie(HttpServletResponse response, String name, String value, int age) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(age);
+        response.addCookie(cookie);
+    }
+
+    public String extractTokenFromCookie(Cookie[] cookies) {
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("token")) {
+                return cookie.getValue();
+            }
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/roomescape/global/auth/JwtProvider.java
+++ b/src/main/java/roomescape/global/auth/JwtProvider.java
@@ -36,16 +36,16 @@ public class JwtProvider {
             .compact();
     }
 
-    public Long getUserId(String token) {
+    public Long getMemberId(String token) {
         try {
-            String userId = Jwts.parserBuilder()
+            String memberId = Jwts.parserBuilder()
                 .setSigningKey(getSecretKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
 
-            return Long.valueOf(userId);
+            return Long.valueOf(memberId);
         } catch (JwtException e) {
             throw new AuthenticationException();
         }

--- a/src/main/java/roomescape/global/auth/JwtProvider.java
+++ b/src/main/java/roomescape/global/auth/JwtProvider.java
@@ -1,0 +1,57 @@
+package roomescape.global.auth;
+
+import java.security.Key;
+import java.util.Base64;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import roomescape.global.exception.AuthenticationException;
+import roomescape.member.Member;
+
+@Component
+public class JwtProvider {
+
+    private final String secretKey;
+
+    public JwtProvider(
+        @Value("${auth.jwt.secret}") String secretKey
+    ) {
+        this.secretKey = secretKey;
+    }
+
+    public String createToken(Member member) {
+        Key key = getSecretKey();
+        return Jwts.builder()
+            .signWith(key)
+            .setSubject(member.getId().toString())
+            .claim("name", member.getName())
+            .claim("role", member.getRole())
+            .compact();
+    }
+
+    public Long getUserId(String token) {
+        try {
+            String userId = Jwts.parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+
+            return Long.valueOf(userId);
+        } catch (JwtException e) {
+            throw new AuthenticationException();
+        }
+    }
+
+    private SecretKey getSecretKey() {
+        String encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        return Keys.hmacShaKeyFor(encoded.getBytes());
+    }
+}

--- a/src/main/java/roomescape/global/auth/JwtProvider.java
+++ b/src/main/java/roomescape/global/auth/JwtProvider.java
@@ -1,5 +1,6 @@
 package roomescape.global.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 
@@ -51,7 +52,6 @@ public class JwtProvider {
     }
 
     private SecretKey getSecretKey() {
-        String encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());
-        return Keys.hmacShaKeyFor(encoded.getBytes());
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/roomescape/global/auth/LoginMember.java
+++ b/src/main/java/roomescape/global/auth/LoginMember.java
@@ -1,0 +1,12 @@
+package roomescape.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+
+}

--- a/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,53 @@
+package roomescape.global.auth;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import roomescape.member.Member;
+import roomescape.member.MemberService;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+    private final CookieUtil cookieUtil;
+
+    @Autowired
+    public LoginMemberArgumentResolver(MemberService memberService, CookieUtil cookieUtil) {
+        this.memberService = memberService;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginMember.class) != null
+            && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        @NotNull MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Cookie[] cookies = request.getCookies();
+
+        String token = cookieUtil.extractTokenFromCookie(cookies);
+
+        if (!token.isEmpty()) {
+            return memberService.getAuth(token);
+        } else{
+            return null;
+        }
+    }
+}

--- a/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
@@ -28,7 +28,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterAnnotation(LoginMember.class) != null
+        return parameter.hasParameterAnnotation(LoginMember.class)
             && parameter.getParameterType().equals(Member.class);
     }
 

--- a/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/global/auth/LoginMemberArgumentResolver.java
@@ -46,8 +46,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
         if (!token.isEmpty()) {
             return memberService.getAuth(token);
-        } else{
-            return null;
         }
+        return null;
     }
 }

--- a/src/main/java/roomescape/global/auth/LoginRequest.java
+++ b/src/main/java/roomescape/global/auth/LoginRequest.java
@@ -1,0 +1,7 @@
+package roomescape.global.auth;
+
+public record LoginRequest(
+    String email,
+    String password
+) {
+}

--- a/src/main/java/roomescape/global/config/WebConfig.java
+++ b/src/main/java/roomescape/global/config/WebConfig.java
@@ -2,23 +2,38 @@ package roomescape.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import roomescape.global.auth.AuthorizationInterceptor;
 import roomescape.global.auth.LoginMemberArgumentResolver;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final AuthorizationInterceptor authorizationInterceptor;
 
-    public WebConfig(final LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    @Autowired
+    public WebConfig(
+        LoginMemberArgumentResolver loginMemberArgumentResolver,
+        AuthorizationInterceptor authorizationInterceptor
+    ) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.authorizationInterceptor = authorizationInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authorizationInterceptor)
+            .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/roomescape/global/config/WebConfig.java
+++ b/src/main/java/roomescape/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package roomescape.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import roomescape.global.auth.LoginMemberArgumentResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(final LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/roomescape/global/exception/AuthenticationException.java
+++ b/src/main/java/roomescape/global/exception/AuthenticationException.java
@@ -1,0 +1,11 @@
+package roomescape.global.exception;
+
+public class AuthenticationException extends RuntimeException{
+
+    public AuthenticationException() {
+    }
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/global/exception/AuthorizationException.java
+++ b/src/main/java/roomescape/global/exception/AuthorizationException.java
@@ -1,0 +1,11 @@
+package roomescape.global.exception;
+
+public class AuthorizationException extends RuntimeException{
+
+    public AuthorizationException() {
+    }
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/member/Member.java
+++ b/src/main/java/roomescape/member/Member.java
@@ -7,6 +7,9 @@ public class Member {
     private String password;
     private String role;
 
+    public Member() {
+    }
+
     public Member(Long id, String name, String email, String role) {
         this.id = id;
         this.name = name;

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -3,6 +3,11 @@ package roomescape.member;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import roomescape.global.auth.AuthResponse;
+import roomescape.global.auth.CookieUtil;
+import roomescape.global.auth.LoginRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,10 +18,13 @@ import java.net.URI;
 
 @RestController
 public class MemberController {
-    private MemberService memberService;
+    private final MemberService memberService;
+    private final CookieUtil cookieUtil;
 
-    public MemberController(MemberService memberService) {
+    @Autowired
+    public MemberController(MemberService memberService, CookieUtil cookieUtil) {
         this.memberService = memberService;
+        this.cookieUtil = cookieUtil;
     }
 
     @PostMapping("/members")
@@ -25,13 +33,28 @@ public class MemberController {
         return ResponseEntity.created(URI.create("/members/" + member.getId())).body(member);
     }
 
+    @PostMapping("/login")
+    public ResponseEntity login(
+        @RequestBody LoginRequest request,
+        HttpServletResponse response
+    ) {
+        String token = memberService.memberLogin(request);
+        cookieUtil.addCookie(response, "token", token, 3600);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity<AuthResponse> checkLogin(HttpServletRequest request) {
+        String token = cookieUtil.extractTokenFromCookie(request.getCookies());
+        Member member = memberService.getAuth(token);
+        var response = AuthResponse.from(member);
+        return ResponseEntity.ok().body(response);
+    }
+
+
     @PostMapping("/logout")
     public ResponseEntity logout(HttpServletResponse response) {
-        Cookie cookie = new Cookie("token", "");
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
+        cookieUtil.addCookie(response, "token", "", 0);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -1,5 +1,8 @@
 package roomescape.member;
 
+import java.util.Optional;
+
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
@@ -51,5 +54,23 @@ public class MemberDao {
                 ),
                 name
         );
+    }
+
+    public Optional<Member> findById(Long id) {
+        try {
+            Member member = jdbcTemplate.queryForObject(
+                "SELECT id, name, email, role FROM member WHERE id = ?",
+                (rs, rowNum) -> new Member(
+                    rs.getLong("id"),
+                    rs.getString("name"),
+                    rs.getString("email"),
+                    rs.getString("role")
+                ),
+                id
+            );
+            return Optional.ofNullable(member);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     }
 
     public Member getAuth(String token) {
-        Long userId = jwtProvider.getUserId(token);
-        return memberDao.findById(userId).orElseThrow(AuthenticationException::new);
+        Long memberId = jwtProvider.getMemberId(token);
+        return memberDao.findById(memberId).orElseThrow(AuthenticationException::new);
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,17 +1,42 @@
 package roomescape.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import roomescape.global.auth.JwtProvider;
+import roomescape.global.auth.LoginRequest;
+import roomescape.global.exception.AuthenticationException;
 
 @Service
+@Transactional(readOnly = true)
 public class MemberService {
-    private MemberDao memberDao;
+    private final MemberDao memberDao;
+    private final JwtProvider jwtProvider;
 
-    public MemberService(MemberDao memberDao) {
+    @Autowired
+    public MemberService(MemberDao memberDao, JwtProvider jwtProvider) {
         this.memberDao = memberDao;
+        this.jwtProvider = jwtProvider;
     }
 
+    @Transactional
     public MemberResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+    }
+
+    public String memberLogin(LoginRequest request) {
+        Member member = memberDao.findByEmailAndPassword(request.email(), request.password());
+        if(member == null) {
+            throw new AuthenticationException("로그인 정보가 존재하지 않습니다.");
+        }
+
+        return jwtProvider.createToken(member);
+    }
+
+    public Member getAuth(String token) {
+        Long userId = jwtProvider.getUserId(token);
+        return memberDao.findById(userId).orElseThrow(AuthenticationException::new);
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 import java.net.URI;
 import java.util.List;
 
+import roomescape.global.auth.LoginMember;
+import roomescape.member.Member;
+
 @RestController
 public class ReservationController {
 
@@ -26,13 +29,28 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+    public ResponseEntity create(
+        @LoginMember Member loginMember,
+        @RequestBody ReservationRequest reservationRequest
+    ) {
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
         }
+
+        if(reservationRequest.getName() == null) {
+            ReservationResponse reservation = reservationService.save(
+                new ReservationRequest(
+                    loginMember.getName(),
+                    reservationRequest.getDate(),
+                    reservationRequest.getTheme(),
+                    reservationRequest.getTime()
+                )
+            );
+            return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
+        }
+
         ReservationResponse reservation = reservationService.save(reservationRequest);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -6,6 +6,16 @@ public class ReservationRequest {
     private Long theme;
     private Long time;
 
+    public ReservationRequest() {
+    }
+
+    public ReservationRequest(String name, String date, Long theme, Long time) {
+        this.name = name;
+        this.date = date;
+        this.theme = theme;
+        this.time = time;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/reservation/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/ReservationResponse.java
@@ -7,6 +7,9 @@ public class ReservationResponse {
     private String date;
     private String time;
 
+    public ReservationResponse() {
+    }
+
     public ReservationResponse(Long id, String name, String theme, String date, String time) {
         this.id = id;
         this.name = name;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -4,7 +4,14 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import roomescape.global.auth.JwtProvider;
+import roomescape.member.Member;
+import roomescape.member.MemberDao;
+import roomescape.member.MemberService;
+import roomescape.reservation.ReservationResponse;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -16,6 +23,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .body(params)
+            .when().post("/login")
+            .then().log().all()
+            .statusCode(200)
+            .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+
+    }
 
     @Test
     void 일단계() {
@@ -34,5 +58,39 @@ public class MissionStepTest {
         String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
 
         assertThat(token).isNotBlank();
+    }
+
+    @Test
+    void 이단계() {
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .body(params)
+            .cookie("token", token)
+            .contentType(ContentType.JSON)
+            .post("/reservations")
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
+            .body(params)
+            .cookie("token", token)
+            .contentType(ContentType.JSON)
+            .post("/reservations")
+            .then().log().all()
+            .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -93,4 +93,23 @@ public class MissionStepTest {
         assertThat(adminResponse.statusCode()).isEqualTo(201);
         assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
     }
+
+    @Test
+    void 삼단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        RestAssured.given().log().all()
+            .cookie("token", brownToken)
+            .get("/admin")
+            .then().log().all()
+            .statusCode(401);
+
+        String adminToken = createToken("admin@email.com", "password");
+
+        RestAssured.given().log().all()
+            .cookie("token", adminToken)
+            .get("/admin")
+            .then().log().all()
+            .statusCode(200);
+    }
 }


### PR DESCRIPTION
### 1단계 로그인
* JWT 토큰을 생성하기 위한 `JwtProvider` 클레스를 정의했습니다. 토큰에는 `Member`의 id, name, role 정보가 담깁니다.
	*  Jwt 토큰을 생성하려면 비밀 키가 필요한데 `secretKey` 문자열을 Base64 형식의 문자열로 인코딩 한 뒤 바이트 배열로 변환한 후 HMAC SHA 알고리즘에 사용할 수 있는 `SecretKey`객체를 생성합니다.
- 쿠키를 생성하고 쿠키에서 토큰을 추출하는 과정을 별도의 클레스 `CookieUtil`에서 메서드로 정의했습니다. (관심사의 분리)

### 2단계 로그인 리팩터링
- 로그인된 멤버의 정보를 담는 별도의 LoginMember 클래스를 생성하는 대신 애너테이션을 사용하여 메서드의 파라미터에 직접 로그인된 회원의 정보를 주입받을 수 있도록 구현했습니다.
- `HandlerMethodArgumentResolver`의 구현체를 만들고 `WebConfig`의 `addArgumentResolvers`에서 등록했습니다.
- 예약을 등록하는 API에서 이름이 없다면 로그인된 회원의 이름 정보를 이용하여 예약하도록 했습니다.
- 테스트코드 `일단계()`를 참고하여 토큰을 생성하는 메서드`createToken`을 추가했습니다.

### 3단계 관리자 기능
- `AuthorizationInterceptor` 클래스를 추가하여 사용자 인증 및 권한 검사를 수행하는 기능을 구현하였습니다. 
- `WebConfig`에서 `addInterceptors`를 통해 Admin 페이지에 진입할 때 권한을 확인합니다.