### PR TITLE
[Spring MVC (인증)] 김진학 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/auth/AdminInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminInterceptor.java
@@ -1,0 +1,41 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AdminInterceptor implements HandlerInterceptor {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AdminInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        Cookie tokenCookie = getCookie(request, "token");
+        Map<String, Object> claims = jwtTokenProvider.getClaims(tokenCookie.getValue());
+        LoginMember member = LoginMember.fromClaims(claims);
+
+        if (member == null || !member.role().equals("ADMIN")) {
+            response.setStatus(401);
+            return false;
+        }
+
+        return true;
+    }
+
+    public Cookie getCookie(HttpServletRequest request, String name) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Empty cookie"));
+    }
+}

--- a/src/main/java/roomescape/auth/AdminInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminInterceptor.java
@@ -22,7 +22,7 @@ public class AdminInterceptor implements HandlerInterceptor {
         String token = authorizationExtractor.extract(request);
         LoginMember loginMember = authService.createAuthentication(token);
 
-        if (!loginMember.isAdmin()) {
+        if (!Role.isAdmin(loginMember.role())) {
             response.setStatus(401);
             return false;
         }

--- a/src/main/java/roomescape/auth/AdminInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminInterceptor.java
@@ -2,17 +2,16 @@ package roomescape.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
 public class AdminInterceptor implements HandlerInterceptor {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthService authService;
     private final AuthorizationExtractor authorizationExtractor;
 
-    public AdminInterceptor(JwtTokenProvider jwtTokenProvider, AuthorizationExtractor authorizationExtractor) {
-        this.jwtTokenProvider = jwtTokenProvider;
+    public AdminInterceptor(AuthService authService, AuthorizationExtractor authorizationExtractor) {
+        this.authService = authService;
         this.authorizationExtractor = authorizationExtractor;
     }
 
@@ -21,10 +20,9 @@ public class AdminInterceptor implements HandlerInterceptor {
             throws Exception {
 
         String token = authorizationExtractor.extract(request);
-        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
-        LoginMember member = LoginMember.fromClaims(claims);
+        LoginMember loginMember = authService.createAuthentication(token);
 
-        if (member == null || !member.role().equals("ADMIN")) {
+        if (!loginMember.role().equals("ADMIN")) {
             response.setStatus(401);
             return false;
         }

--- a/src/main/java/roomescape/auth/AdminInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminInterceptor.java
@@ -22,7 +22,7 @@ public class AdminInterceptor implements HandlerInterceptor {
         String token = authorizationExtractor.extract(request);
         LoginMember loginMember = authService.createAuthentication(token);
 
-        if (!loginMember.role().equals("ADMIN")) {
+        if (!loginMember.isAdmin()) {
             response.setStatus(401);
             return false;
         }

--- a/src/main/java/roomescape/auth/AdminInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminInterceptor.java
@@ -1,9 +1,7 @@
 package roomescape.auth;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -11,17 +9,19 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class AdminInterceptor implements HandlerInterceptor {
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthorizationExtractor authorizationExtractor;
 
-    public AdminInterceptor(JwtTokenProvider jwtTokenProvider) {
+    public AdminInterceptor(JwtTokenProvider jwtTokenProvider, AuthorizationExtractor authorizationExtractor) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.authorizationExtractor = authorizationExtractor;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
 
-        Cookie tokenCookie = getCookie(request, "token");
-        Map<String, Object> claims = jwtTokenProvider.getClaims(tokenCookie.getValue());
+        String token = authorizationExtractor.extract(request);
+        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
         LoginMember member = LoginMember.fromClaims(claims);
 
         if (member == null || !member.role().equals("ADMIN")) {
@@ -30,12 +30,5 @@ public class AdminInterceptor implements HandlerInterceptor {
         }
 
         return true;
-    }
-
-    public Cookie getCookie(HttpServletRequest request, String name) {
-        return Arrays.stream(request.getCookies())
-                .filter(cookie -> cookie.getName().equals(name))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Empty cookie"));
     }
 }

--- a/src/main/java/roomescape/auth/AuthController.java
+++ b/src/main/java/roomescape/auth/AuthController.java
@@ -3,11 +3,9 @@ package roomescape.auth;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,10 +34,9 @@ public class AuthController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity check(@CookieValue(name = TOKEN_COOKIE) String token) {
+    public ResponseEntity check(LoginMember loginMember) {
         try {
-            Map<String, Object> claims = authService.extractClaims(token);
-            return ResponseEntity.ok().body(claims);
+            return ResponseEntity.ok().body(loginMember);
         } catch (JwtException | IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
         }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -1,6 +1,6 @@
 package roomescape.auth;
 
-import java.util.Map;
+import io.jsonwebtoken.Claims;
 import org.springframework.stereotype.Service;
 import roomescape.member.Member;
 import roomescape.member.MemberDao;
@@ -21,7 +21,7 @@ public class AuthService {
     }
 
     public LoginMember createAuthentication(String token) {
-        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
-        return LoginMember.fromClaims(claims);
+        Claims claims = jwtTokenProvider.getClaims(token);
+        return LoginMember.from(claims);
     }
 }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -23,8 +23,8 @@ public class AuthService {
     public LoginMember createAuthentication(String token) {
         Claims claims = jwtTokenProvider.getClaims(token);
         return new LoginMember(
-                claims.getSubject(),
-                claims.get("name", String.class),
-                Role.valueOf(claims.get("role", String.class)));
+                JwtTokenProvider.extract(claims, "sub"),
+                JwtTokenProvider.extract(claims, "name"),
+                Role.valueOf(JwtTokenProvider.extract(claims, "role")));
     }
 }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -22,6 +22,9 @@ public class AuthService {
 
     public LoginMember createAuthentication(String token) {
         Claims claims = jwtTokenProvider.getClaims(token);
-        return LoginMember.from(claims);
+        return new LoginMember(
+                claims.getSubject(),
+                claims.get("name", String.class),
+                Role.valueOf(claims.get("role", String.class)));
     }
 }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -20,7 +20,8 @@ public class AuthService {
         return jwtTokenProvider.createToken(member);
     }
 
-    public Map<String, Object> extractClaims(String token) {
-        return jwtTokenProvider.getClaims(token);
+    public LoginMember createAuthentication(String token) {
+        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
+        return LoginMember.fromClaims(claims);
     }
 }

--- a/src/main/java/roomescape/auth/AuthorizationExtractor.java
+++ b/src/main/java/roomescape/auth/AuthorizationExtractor.java
@@ -1,0 +1,7 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface AuthorizationExtractor {
+    String extract(HttpServletRequest request);
+}

--- a/src/main/java/roomescape/auth/CookieAuthorizationExtractor.java
+++ b/src/main/java/roomescape/auth/CookieAuthorizationExtractor.java
@@ -1,0 +1,20 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieAuthorizationExtractor implements AuthorizationExtractor {
+    private static final String AUTHORIZATION_NAME = "token";
+
+    @Override
+    public String extract(HttpServletRequest request) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(AUTHORIZATION_NAME))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Empty cookie"));
+    }
+}

--- a/src/main/java/roomescape/auth/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
+import java.util.Optional;
 import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
 import roomescape.member.Member;
@@ -42,5 +43,10 @@ public class JwtTokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public static String extract(Claims claims, String key) {
+        return Optional.ofNullable(claims.get(key, String.class))
+                .orElseThrow(() -> new IllegalArgumentException("Invalid claims"));
     }
 }

--- a/src/main/java/roomescape/auth/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/JwtTokenProvider.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
-import java.util.Map;
 import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
 import roomescape.member.Member;
@@ -37,7 +36,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Map<String, Object> getClaims(String token) {
+    public Claims getClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()

--- a/src/main/java/roomescape/auth/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/JwtTokenProvider.java
@@ -14,15 +14,17 @@ public class JwtTokenProvider {
 
     private final SecretKey secretKey;
     private final long validityInMilliseconds;
+    private final TimeProvider timeProvider;
 
-    public JwtTokenProvider(JwtProperties jwtProperties) {
+    public JwtTokenProvider(JwtProperties jwtProperties, TimeProvider timeProvider) {
         this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
         this.validityInMilliseconds = jwtProperties.getValidityInMilliseconds();
+        this.timeProvider = timeProvider;
     }
 
     public String createToken(Member member) {
         Claims claims = Jwts.claims().setSubject(member.getEmail());
-        Date now = new Date();
+        Date now = timeProvider.now();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,16 +1,16 @@
 package roomescape.auth;
 
-import java.util.Map;
+import io.jsonwebtoken.Claims;
 
 public record LoginMember(
         String email,
         String name,
         String role
 ) {
-    public static LoginMember fromClaims(Map<String, Object> claims) {
-        String email = (String) claims.get("sub");
-        String name = (String) claims.get("name");
-        String role = (String) claims.get("role");
-        return new LoginMember(email, name, role);
+    public static LoginMember from(Claims claims) {
+        return new LoginMember(
+                claims.getSubject(),
+                claims.get("name", String.class),
+                claims.get("role", String.class));
     }
 }

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -5,4 +5,30 @@ public record LoginMember(
         String name,
         Role role
 ) {
+    public LoginMember(String email, String name, Role role) {
+        validateEmail(email);
+        validateName(name);
+        validateRole(role);
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Invalid email");
+        }
+    }
+
+    private void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Invalid name");
+        }
+    }
+
+    private void validateRole(Role role) {
+        if (role == null) {
+            throw new IllegalArgumentException("Invalid role");
+        }
+    }
 }

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,8 +1,16 @@
 package roomescape.auth;
 
+import java.util.Map;
+
 public record LoginMember(
         String email,
         String name,
         String password
 ) {
+    public static LoginMember fromClaims(Map<String, Object> claims) {
+        String email = (String) claims.get("sub");
+        String name = (String) claims.get("name");
+        String role = (String) claims.get("role");
+        return new LoginMember(email, name, role);
+    }
 }

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,5 +1,6 @@
 package roomescape.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.jsonwebtoken.Claims;
 
 public record LoginMember(
@@ -12,5 +13,10 @@ public record LoginMember(
                 claims.getSubject(),
                 claims.get("name", String.class),
                 claims.get("role", String.class));
+    }
+
+    @JsonIgnore
+    public boolean isAdmin() {
+        return this.role.equals("ADMIN");
     }
 }

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,0 +1,8 @@
+package roomescape.auth;
+
+public record LoginMember(
+        String email,
+        String name,
+        String password
+) {
+}

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,22 +1,16 @@
 package roomescape.auth;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.jsonwebtoken.Claims;
 
 public record LoginMember(
         String email,
         String name,
-        String role
+        Role role
 ) {
     public static LoginMember from(Claims claims) {
         return new LoginMember(
                 claims.getSubject(),
                 claims.get("name", String.class),
-                claims.get("role", String.class));
-    }
-
-    @JsonIgnore
-    public boolean isAdmin() {
-        return this.role.equals("ADMIN");
+                Role.valueOf(claims.get("role", String.class)));
     }
 }

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -5,7 +5,7 @@ import java.util.Map;
 public record LoginMember(
         String email,
         String name,
-        String password
+        String role
 ) {
     public static LoginMember fromClaims(Map<String, Object> claims) {
         String email = (String) claims.get("sub");

--- a/src/main/java/roomescape/auth/LoginMember.java
+++ b/src/main/java/roomescape/auth/LoginMember.java
@@ -1,16 +1,8 @@
 package roomescape.auth;
 
-import io.jsonwebtoken.Claims;
-
 public record LoginMember(
         String email,
         String name,
         Role role
 ) {
-    public static LoginMember from(Claims claims) {
-        return new LoginMember(
-                claims.getSubject(),
-                claims.get("name", String.class),
-                Role.valueOf(claims.get("role", String.class)));
-    }
 }

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,8 +1,6 @@
 package roomescape.auth;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Arrays;
 import java.util.Map;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -10,14 +8,16 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import roomescape.member.MemberService;
 
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthorizationExtractor authorizationExtractor;
 
-    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider, MemberService memberService) {
+    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider,
+                                       AuthorizationExtractor authorizationExtractor) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.authorizationExtractor = authorizationExtractor;
     }
 
     @Override
@@ -28,15 +28,8 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        Cookie tokenCookie = getCookie((HttpServletRequest) webRequest.getNativeRequest(), "token");
-        Map<String, Object> claims = jwtTokenProvider.getClaims(tokenCookie.getValue());
+        String token = authorizationExtractor.extract((HttpServletRequest) webRequest.getNativeRequest());
+        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
         return LoginMember.fromClaims(claims);
-    }
-
-    public Cookie getCookie(HttpServletRequest request, String name) {
-        return Arrays.stream(request.getCookies())
-                .filter(cookie -> cookie.getName().equals(name))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Empty cookie"));
     }
 }

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,47 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Map;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import roomescape.member.MemberService;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider, MemberService memberService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Cookie tokenCookie = getCookie((HttpServletRequest) webRequest.getNativeRequest(), "token");
+
+        Map<String, Object> claims = jwtTokenProvider.getClaims(tokenCookie.getValue());
+        String email = (String) claims.get("sub");
+        String name = (String) claims.get("name");
+        String role = (String) claims.get("role");
+
+        return new LoginMember(email, name, role);
+    }
+
+    public Cookie getCookie(HttpServletRequest request, String name) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Empty cookie"));
+    }
+}

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -29,13 +29,8 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         Cookie tokenCookie = getCookie((HttpServletRequest) webRequest.getNativeRequest(), "token");
-
         Map<String, Object> claims = jwtTokenProvider.getClaims(tokenCookie.getValue());
-        String email = (String) claims.get("sub");
-        String name = (String) claims.get("name");
-        String role = (String) claims.get("role");
-
-        return new LoginMember(email, name, role);
+        return LoginMember.fromClaims(claims);
     }
 
     public Cookie getCookie(HttpServletRequest request, String name) {

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,7 +1,6 @@
 package roomescape.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Map;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -11,12 +10,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthService authService;
     private final AuthorizationExtractor authorizationExtractor;
 
-    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider,
-                                       AuthorizationExtractor authorizationExtractor) {
-        this.jwtTokenProvider = jwtTokenProvider;
+    public LoginMemberArgumentResolver(AuthService authService, AuthorizationExtractor authorizationExtractor) {
+        this.authService = authService;
         this.authorizationExtractor = authorizationExtractor;
     }
 
@@ -29,7 +27,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         String token = authorizationExtractor.extract((HttpServletRequest) webRequest.getNativeRequest());
-        Map<String, Object> claims = jwtTokenProvider.getClaims(token);
-        return LoginMember.fromClaims(claims);
+        return authService.createAuthentication(token);
     }
 }

--- a/src/main/java/roomescape/auth/Role.java
+++ b/src/main/java/roomescape/auth/Role.java
@@ -1,0 +1,9 @@
+package roomescape.auth;
+
+public enum Role {
+    ADMIN, USER;
+
+    static boolean isAdmin(Role role) {
+        return role == ADMIN;
+    }
+}

--- a/src/main/java/roomescape/auth/SystemTimeProvider.java
+++ b/src/main/java/roomescape/auth/SystemTimeProvider.java
@@ -1,0 +1,12 @@
+package roomescape.auth;
+
+import java.util.Date;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SystemTimeProvider implements TimeProvider {
+    @Override
+    public Date now() {
+        return new Date();
+    }
+}

--- a/src/main/java/roomescape/auth/TimeProvider.java
+++ b/src/main/java/roomescape/auth/TimeProvider.java
@@ -1,0 +1,7 @@
+package roomescape.auth;
+
+import java.util.Date;
+
+public interface TimeProvider {
+    Date now();
+}

--- a/src/main/java/roomescape/auth/WebConfig.java
+++ b/src/main/java/roomescape/auth/WebConfig.java
@@ -1,0 +1,20 @@
+package roomescape.auth;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/roomescape/auth/WebConfig.java
+++ b/src/main/java/roomescape/auth/WebConfig.java
@@ -3,18 +3,27 @@ package roomescape.auth;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final AdminInterceptor adminInterceptor;
 
-    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver, AdminInterceptor adminInterceptor) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.adminInterceptor = adminInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminInterceptor)
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -30,7 +30,7 @@ public class ReservationController {
         if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body("Invalid reservation request");
         }
 
         if (reservationRequest.getName() == null) {

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -1,5 +1,7 @@
 package roomescape.reservation;
 
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,9 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
-import java.util.List;
+import roomescape.auth.LoginMember;
 
 @RestController
 public class ReservationController {
@@ -26,12 +26,16 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
+        }
+
+        if (reservationRequest.getName() == null) {
+            reservationRequest = new ReservationRequest(loginMember.name(), reservationRequest.getDate(),
+                    reservationRequest.getTheme(), reservationRequest.getTime());
         }
         ReservationResponse reservation = reservationService.save(reservationRequest);
 

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -27,16 +27,7 @@ public class ReservationController {
 
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
-        if (reservationRequest.getDate() == null
-                || reservationRequest.getTheme() == null
-                || reservationRequest.getTime() == null) {
-            return ResponseEntity.badRequest().body("Invalid reservation request");
-        }
-
-        if (reservationRequest.getName() == null) {
-            reservationRequest = new ReservationRequest(loginMember.name(), reservationRequest.getDate(),
-                    reservationRequest.getTheme(), reservationRequest.getTime());
-        }
+        reservationRequest.checkName(loginMember.name());
         ReservationResponse reservation = reservationService.save(reservationRequest);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -6,6 +6,13 @@ public class ReservationRequest {
     private Long theme;
     private Long time;
 
+    public ReservationRequest(String name, String date, Long theme, Long time) {
+        this.name = name;
+        this.date = date;
+        this.theme = theme;
+        this.time = time;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -7,6 +7,9 @@ public class ReservationRequest {
     private Long time;
 
     public ReservationRequest(String name, String date, Long theme, Long time) {
+        validateDate(date);
+        validateTheme(theme);
+        validateTime(time);
         this.name = name;
         this.date = date;
         this.theme = theme;
@@ -27,5 +30,29 @@ public class ReservationRequest {
 
     public Long getTime() {
         return time;
+    }
+
+    public void checkName(String name) {
+        if (this.name == null) {
+            this.name = name;
+        }
+    }
+
+    private void validateDate(String date) {
+        if (date == null) {
+            throw new IllegalArgumentException("Invalid date");
+        }
+    }
+
+    private void validateTheme(Long theme) {
+        if (theme == null) {
+            throw new IllegalArgumentException("Invalid theme");
+        }
+    }
+
+    private void validateTime(Long time) {
+        if (time == null) {
+            throw new IllegalArgumentException("Invalid time");
+        }
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.ReservationResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -42,5 +43,55 @@ public class MissionStepTest {
                 .extract();
 
         assertThat(checkResponse.body().jsonPath().getString("name")).isEqualTo("어드민");
+    }
+
+    @Test
+    void 이단계() {
+        String token = createToken("admin@email.com", "password");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+    }
+
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -94,4 +94,23 @@ public class MissionStepTest {
 
         return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
     }
+
+    @Test
+    void 삼단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        String adminToken = createToken("admin@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
+    }
 }

--- a/src/test/java/roomescape/auth/AuthServiceTest.java
+++ b/src/test/java/roomescape/auth/AuthServiceTest.java
@@ -1,0 +1,42 @@
+package roomescape.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import roomescape.member.Member;
+import roomescape.member.MemberDao;
+
+class AuthServiceTest {
+    private final String originSecretKey = "ThisIsATestKeyForJsonWebTokenProvider";
+    private final long originValidity = 6000;
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
+            new JwtProperties(originSecretKey, originValidity),
+            new SystemTimeProvider());
+
+    private final Member member = new Member(1L, "test", "test@email.com", "ADMIN");
+    private final MemberDao memberDao = new MemberDao(new JdbcTemplate());
+    private final AuthService authService = new AuthService(jwtTokenProvider, memberDao);
+
+    @Test
+    void 토큰의_키가_존재하지_않는_경우_토큰_정보_조회에_실패한다() {
+        //given
+        Date now = new SystemTimeProvider().now();
+        Date validity = new Date(now.getTime() + originValidity);
+
+        String token = Jwts.builder()
+                .setSubject(member.getEmail())
+                .claim("name", member.getName())
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(Keys.hmacShaKeyFor(originSecretKey.getBytes()))
+                .compact();
+
+        //when, then
+        assertThatThrownBy(() -> authService.createAuthentication(token))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/roomescape/auth/JwtTokenProviderTest.java
+++ b/src/test/java/roomescape/auth/JwtTokenProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import java.util.Date;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import roomescape.member.Member;
@@ -13,8 +14,22 @@ class JwtTokenProviderTest {
     private final String originSecretKey = "ThisIsATestKeyForJsonWebTokenProvider";
     private final long originValidity = 6000;
     private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
-            new JwtProperties(originSecretKey, originValidity));
+            new JwtProperties(originSecretKey, originValidity),
+            new SystemTimeProvider());
     private final Member member = new Member(1L, "test", "test@email.com", "ADMIN");
+
+    static class MockTimeProvider implements TimeProvider {
+        private final Date mockDate;
+
+        public MockTimeProvider(Date mockDate) {
+            this.mockDate = mockDate;
+        }
+
+        @Override
+        public Date now() {
+            return mockDate;
+        }
+    }
 
     @Test
     void 토큰_생성_성공() {
@@ -42,7 +57,9 @@ class JwtTokenProviderTest {
     @Test
     void 토큰이_만료된_경우_토큰_정보_조회에_실패한다() {
         //given
-        JwtTokenProvider otherProvider = new JwtTokenProvider(new JwtProperties(originSecretKey, 0));
+        JwtTokenProvider otherProvider = new JwtTokenProvider(
+                new JwtProperties(originSecretKey, originValidity),
+                new MockTimeProvider(new Date(new Date().getTime() - originValidity)));
         String expireToken = otherProvider.createToken(member);
 
         //when, then
@@ -54,7 +71,8 @@ class JwtTokenProviderTest {
     void 토큰의_서명이_다른_경우_토큰_정보_조회에_실패한다() {
         //given
         JwtTokenProvider otherProvider = new JwtTokenProvider(
-                new JwtProperties(originSecretKey + " ", originValidity));
+                new JwtProperties(originSecretKey + " ", originValidity),
+                new SystemTimeProvider());
         String alteredSignatureToken = otherProvider.createToken(member);
 
         //when, then

--- a/src/test/java/roomescape/auth/JwtTokenProviderTest.java
+++ b/src/test/java/roomescape/auth/JwtTokenProviderTest.java
@@ -12,13 +12,9 @@ import roomescape.member.Member;
 class JwtTokenProviderTest {
     private final String originSecretKey = "ThisIsATestKeyForJsonWebTokenProvider";
     private final long originValidity = 6000;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final Member member;
-
-    public JwtTokenProviderTest() {
-        this.jwtTokenProvider = new JwtTokenProvider(new JwtProperties(originSecretKey, originValidity));
-        this.member = new Member(1L, "test", "test@email.com", "ADMIN");
-    }
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
+            new JwtProperties(originSecretKey, originValidity));
+    private final Member member = new Member(1L, "test", "test@email.com", "ADMIN");
 
     @Test
     void 토큰_생성_성공() {

--- a/src/test/java/roomescape/auth/LoginCheckTest.java
+++ b/src/test/java/roomescape/auth/LoginCheckTest.java
@@ -28,7 +28,7 @@ public class LoginCheckTest {
 
         assertThat(loginMember.name()).isEqualTo("어드민");
         assertThat(loginMember.email()).isEqualTo("admin@email.com");
-        assertThat(loginMember.role()).isEqualTo("ADMIN");
+        assertThat(loginMember.role()).isEqualTo(Role.ADMIN);
     }
 
     @Test

--- a/src/test/java/roomescape/auth/LoginCheckTest.java
+++ b/src/test/java/roomescape/auth/LoginCheckTest.java
@@ -6,11 +6,30 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class LoginCheckTest {
+
+    @Test
+    void 인증_정보_조회_성공() {
+        String token = createToken("admin@email.com", "password");
+
+        LoginMember loginMember = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/login/check")
+                .then().log().all()
+                .statusCode(200)
+                .extract().as(LoginMember.class);
+
+        assertThat(loginMember.name()).isEqualTo("어드민");
+        assertThat(loginMember.email()).isEqualTo("admin@email.com");
+        assertThat(loginMember.role()).isEqualTo("ADMIN");
+    }
 
     @Test
     void 인증_토큰_쿠키가_비어있는_경우_인증_정보_조회에_실패한다() {
@@ -23,5 +42,21 @@ public class LoginCheckTest {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
     }
 }

--- a/src/test/java/roomescape/auth/LoginMemberTest.java
+++ b/src/test/java/roomescape/auth/LoginMemberTest.java
@@ -1,0 +1,33 @@
+package roomescape.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LoginMemberTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    void 이메일이_유효하지_않은_경우_예외가_발생한다(String email) {
+        assertThatThrownBy(() -> new LoginMember(
+                email, "어드민", Role.ADMIN
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    void 이름이_유효하지_않은_경우_예외가_발생한다(String name) {
+        assertThatThrownBy(() -> new LoginMember(
+                "admin@email.com", name, Role.ADMIN
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    void 역할이_유효하지_않은_경우_예외가_발생한다(String role) {
+        assertThatThrownBy(() -> new LoginMember(
+                "admin@email.com", "어드민", Role.valueOf(role)
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/roomescape/auth/LoginTest.java
+++ b/src/test/java/roomescape/auth/LoginTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class LoginTest {
     @Test
-    void 로그인_성공() {
+    void 로그인에_성공한_경우_토큰을_쿠키에_저장한다() {
         //given
         Map<String, String> validCredentials = new HashMap<>();
         validCredentials.put("email", "admin@email.com");

--- a/src/test/java/roomescape/reservation/CreateReservations.java
+++ b/src/test/java/roomescape/reservation/CreateReservations.java
@@ -1,0 +1,100 @@
+package roomescape.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+class CreateReservations {
+
+    @Test
+    void 로그인_상태에서_예약자명이_존재하지않는_경우_로그인_정보명으로_예약된다() {
+        //given
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", "2024-03-01");
+        reservationRequest.put("time", "1");
+        reservationRequest.put("theme", "1");
+
+        //when
+        ReservationResponse reservationResponse = RestAssured.given().log().all()
+                .body(reservationRequest)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract().as(ReservationResponse.class);
+
+        //then
+        assertThat(reservationResponse.getName()).isEqualTo("어드민");
+    }
+
+    @Test
+    void 로그인_상태에서_예약자명이_존재하는_경우_예약자명으로_예약된다() {
+        //given
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", "2024-03-01");
+        reservationRequest.put("name", "브라운");
+        reservationRequest.put("time", "1");
+        reservationRequest.put("theme", "1");
+
+        //when
+        ReservationResponse reservationResponse = RestAssured.given().log().all()
+                .body(reservationRequest)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract().as(ReservationResponse.class);
+
+        //then
+        assertThat(reservationResponse.getName()).isEqualTo("브라운");
+    }
+
+    @Test
+    void 비로그인_상태에서_예약할_경우_예약에_실패한다() {
+        //given
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", "2024-03-01");
+        reservationRequest.put("name", "브라운");
+        reservationRequest.put("time", "1");
+        reservationRequest.put("theme", "1");
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(reservationRequest)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+    }
+}

--- a/src/test/java/roomescape/reservation/CreateReservations.java
+++ b/src/test/java/roomescape/reservation/CreateReservations.java
@@ -88,7 +88,6 @@ class CreateReservations {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
-        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
     }
 
     @Test
@@ -107,7 +106,6 @@ class CreateReservations {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
-        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
     }
 
     @Test
@@ -126,7 +124,6 @@ class CreateReservations {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
-        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
     }
 
     private ExtractableResponse<Response> sendCreateReservationsRequest(Map<String, String> reservationRequest,

--- a/src/test/java/roomescape/reservation/CreateReservations.java
+++ b/src/test/java/roomescape/reservation/CreateReservations.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class CreateReservations {
-
+    
     @Test
     void 로그인_상태에서_예약자명이_존재하지않는_경우_로그인_정보명으로_예약된다() {
         //given

--- a/src/test/java/roomescape/reservation/CreateReservations.java
+++ b/src/test/java/roomescape/reservation/CreateReservations.java
@@ -25,13 +25,8 @@ class CreateReservations {
         reservationRequest.put("theme", "1");
 
         //when
-        ReservationResponse reservationResponse = RestAssured.given().log().all()
-                .body(reservationRequest)
-                .cookie("token", token)
-                .contentType(ContentType.JSON)
-                .post("/reservations")
-                .then().log().all()
-                .extract().as(ReservationResponse.class);
+        ReservationResponse reservationResponse = sendCreateReservationsRequest(reservationRequest, token).as(
+                ReservationResponse.class);
 
         //then
         assertThat(reservationResponse.getName()).isEqualTo("어드민");
@@ -49,13 +44,8 @@ class CreateReservations {
         reservationRequest.put("theme", "1");
 
         //when
-        ReservationResponse reservationResponse = RestAssured.given().log().all()
-                .body(reservationRequest)
-                .cookie("token", token)
-                .contentType(ContentType.JSON)
-                .post("/reservations")
-                .then().log().all()
-                .extract().as(ReservationResponse.class);
+        ReservationResponse reservationResponse = sendCreateReservationsRequest(reservationRequest, token).as(
+                ReservationResponse.class);
 
         //then
         assertThat(reservationResponse.getName()).isEqualTo("브라운");
@@ -80,6 +70,74 @@ class CreateReservations {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void 유효하지_않은_예약_날짜인_경우_예약에_실패한다() {
+        //given
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", null);
+        reservationRequest.put("name", "브라운");
+        reservationRequest.put("time", "1");
+        reservationRequest.put("theme", "1");
+
+        //when
+        ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
+    }
+
+    @Test
+    void 유효하지_않은_예약_시간인_경우_예약에_실패한다() {
+        //given
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", "2024-03-01");
+        reservationRequest.put("name", "브라운");
+        reservationRequest.put("time", null);
+        reservationRequest.put("theme", "1");
+
+        //when
+        ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
+    }
+
+    @Test
+    void 유효하지_않은_예약_테마인_경우_예약에_실패한다() {
+        //given
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> reservationRequest = new HashMap<>();
+        reservationRequest.put("date", "2024-03-01");
+        reservationRequest.put("name", "브라운");
+        reservationRequest.put("time", "1");
+        reservationRequest.put("theme", null);
+
+        //when
+        ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body().asString()).isEqualTo("Invalid reservation request");
+    }
+
+    private ExtractableResponse<Response> sendCreateReservationsRequest(Map<String, String> reservationRequest,
+                                                                        String token) {
+        return RestAssured.given().log().all()
+                .body(reservationRequest)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
     }
 
     private String createToken(String email, String password) {

--- a/src/test/java/roomescape/reservation/CreateReservations.java
+++ b/src/test/java/roomescape/reservation/CreateReservations.java
@@ -8,6 +8,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -18,11 +19,7 @@ class CreateReservations {
     void 로그인_상태에서_예약자명이_존재하지않는_경우_로그인_정보명으로_예약된다() {
         //given
         String token = createToken("admin@email.com", "password");
-
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", "2024-03-01");
-        reservationRequest.put("time", "1");
-        reservationRequest.put("theme", "1");
+        Map<String, String> reservationRequest = createReservationRequest("2024-03-01", null, "1", "1");
 
         //when
         ReservationResponse reservationResponse = sendCreateReservationsRequest(reservationRequest, token).as(
@@ -36,12 +33,7 @@ class CreateReservations {
     void 로그인_상태에서_예약자명이_존재하는_경우_예약자명으로_예약된다() {
         //given
         String token = createToken("admin@email.com", "password");
-
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", "2024-03-01");
-        reservationRequest.put("name", "브라운");
-        reservationRequest.put("time", "1");
-        reservationRequest.put("theme", "1");
+        Map<String, String> reservationRequest = createReservationRequest("2024-03-01", "브라운", "1", "1");
 
         //when
         ReservationResponse reservationResponse = sendCreateReservationsRequest(reservationRequest, token).as(
@@ -54,11 +46,7 @@ class CreateReservations {
     @Test
     void 비로그인_상태에서_예약할_경우_예약에_실패한다() {
         //given
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", "2024-03-01");
-        reservationRequest.put("name", "브라운");
-        reservationRequest.put("time", "1");
-        reservationRequest.put("theme", "1");
+        Map<String, String> reservationRequest = createReservationRequest("2024-03-01", "브라운", "1", "1");
 
         //when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -76,12 +64,7 @@ class CreateReservations {
     void 유효하지_않은_예약_날짜인_경우_예약에_실패한다() {
         //given
         String token = createToken("admin@email.com", "password");
-
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", null);
-        reservationRequest.put("name", "브라운");
-        reservationRequest.put("time", "1");
-        reservationRequest.put("theme", "1");
+        Map<String, String> reservationRequest = createReservationRequest(null, "브라운", "1", "1");
 
         //when
         ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
@@ -94,12 +77,7 @@ class CreateReservations {
     void 유효하지_않은_예약_시간인_경우_예약에_실패한다() {
         //given
         String token = createToken("admin@email.com", "password");
-
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", "2024-03-01");
-        reservationRequest.put("name", "브라운");
-        reservationRequest.put("time", null);
-        reservationRequest.put("theme", "1");
+        Map<String, String> reservationRequest = createReservationRequest("2024-03-01", "브라운", null, "1");
 
         //when
         ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
@@ -112,18 +90,31 @@ class CreateReservations {
     void 유효하지_않은_예약_테마인_경우_예약에_실패한다() {
         //given
         String token = createToken("admin@email.com", "password");
-
-        Map<String, String> reservationRequest = new HashMap<>();
-        reservationRequest.put("date", "2024-03-01");
-        reservationRequest.put("name", "브라운");
-        reservationRequest.put("time", "1");
-        reservationRequest.put("theme", null);
+        Map<String, String> reservationRequest = createReservationRequest("2024-03-01", "브라운", "1", null);
 
         //when
         ExtractableResponse<Response> response = sendCreateReservationsRequest(reservationRequest, token);
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    @NotNull
+    private Map<String, String> createReservationRequest(String date, String name, String time, String theme) {
+        Map<String, String> reservationRequest = new HashMap<>();
+        if (date != null) {
+            reservationRequest.put("date", date);
+        }
+        if (name != null) {
+            reservationRequest.put("name", name);
+        }
+        if (time != null) {
+            reservationRequest.put("time", time);
+        }
+        if (theme != null) {
+            reservationRequest.put("theme", theme);
+        }
+        return reservationRequest;
     }
 
     private ExtractableResponse<Response> sendCreateReservationsRequest(Map<String, String> reservationRequest,


### PR DESCRIPTION
## 🏃‍♂️ 과정

이전 단계의 리뷰를 추가로 반영하고 새 단계의 요구사항을 추가했습니다. 역할 분리와 테스트에 대한 관점이 조금씩 만들어지는 것 같습니다. 이번 리뷰도 잘 부탁드립니다.

> `만료` 는 비즈니스 상 충분히 발생할 수 있는 요소라 생각합니다.
> 

> 이런 맥락에서 자신이 `이 내용은 여기서 테스트를 해야겠다.` `이 부분은 또 테스트를 할 필요 없겠는데.` 를 만들어가면 좋을거 같아요.
> 
- 테스트명 수정
- 토큰 서명 단위 테스트 삭제: 라이브러리의 일반적인(응답 비교) 검증은 제외
- 토큰 만료 단위 테스트 수정: 비즈니스 상 발생할 가능성이 높은 테스트 환경 조성을 위해 토큰 생성 객체에서 토큰 생성 날짜를 외부 객체에서 주입받아 역할을 분리
- 응답 바디 텍스트 검증 유지: 직관적인 메세지를 확인하기 위해 예상되는 예외가 올바른 메세지를 가지는지 확인

## **📃 요구사항**

### **로그인 리팩터링**

**로직**

- [x]  HandlerMethodArgumentResolver 를 사용하여 컨트롤러 진입 전 인증 정보 검증

### **예약 생성 기능 변경**

**로직**

- [x]  name이 없는 경우 Cookie에서 인증 정보 추출 후 예약하는 기능 추가

**예외**

- [x]  로그인을 하지 않은 경우
- [x]  예약 정보가 유효하지 않은 경우

### **관리자 기능**

**로직**

- [x]  /admin 으로 시작하는 모든 경로는 admin 권한이 있는 사람만 접근할 수 있도록 제한
- 컨트롤러 이전 단계에서 관리자 권한을 검증하는 HandlerIntercepter 과 로그인 객체를 생성하는 HandlerMethodArgumentResolver 동작 중, 쿠키에서 인증 토큰을 추출하고 객체를 생성하는 동작이 중복되었습니다. 이에 인증 토큰을 추출하는 역할은 AuthorizationExtractor 와 CookieAuthorizationExtractor 로 분리하게 되었고, 인증 객체를 생성하는 역할은 AuthService 에 두게 되었습니다.

## 🔎 궁금한점

로그인 상태가 필요한 모든 기능들에 대해서 로그인 요청 로직이 중복되었습니다. 이에 따라 아래와 같은 방법을 생각해보았습니다.

- 로그인과 같이 공통적으로 사용되는 로직을 객체로 분리하여 테스트에서 주입받는 방법: createToken 메서드의 경우 다른 곳에서도 사용될 가능성이 높다고 생각합니다.
- 이전에 작성한 테스트 객체를 주입받아 성공 메서드를 재사용하는 방법: 로그인 요청이 성공해야 하므로 로그인 성공 테스트 메서드를 사용할 수 있다고 생각합니다.

연쇄적으로 일어나야 하는 테스트에 대해서 이전 단계가 성공했다고 가정하고 단위 테스트로 쪼개거나, 통합 테스트에서 중복을 해결해야할 것으로 생각되는데 생각의 방향이 맞는지 궁금합니다.