### PR TITLE
[Spring Data JPA] 김진학 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/member/MemberRepository.java
+++ b/src/main/java/roomescape/member/MemberRepository.java
@@ -4,5 +4,13 @@ import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 public interface MemberRepository extends CrudRepository<Member, Long> {
+
+    default Member findByEmailOrThrow(String email) {
+        return findByEmail(email).orElseThrow(
+                () -> new IllegalArgumentException(String.format("Member not found: %s", email)));
+    }
+
+    Optional<Member> findByEmail(String email);
+
     Optional<Member> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/roomescape/reservation/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/MyReservationResponse.java
@@ -1,5 +1,8 @@
 package roomescape.reservation;
 
+import roomescape.waiting.Waiting;
+import roomescape.waiting.WaitingWithRank;
+
 public record MyReservationResponse(
         Long id,
         String theme,
@@ -7,13 +10,24 @@ public record MyReservationResponse(
         String time,
         String status
 ) {
-    static MyReservationResponse from(Reservation reservation) {
+    public static MyReservationResponse from(Reservation reservation) {
         return new MyReservationResponse(
                 reservation.getId(),
                 reservation.getTheme().getName(),
                 reservation.getDate(),
                 reservation.getTime().getValue(),
                 "예약");
+    }
+
+    public static MyReservationResponse from(WaitingWithRank waitingWithRank) {
+        Waiting waiting = waitingWithRank.getWaiting();
+        return new MyReservationResponse(
+                waiting.getId(),
+                waiting.getTheme().getName(),
+                waiting.getDate(),
+                waiting.getTime().getValue(),
+                waitingWithRank.getRank() + 1 + "번째 예약대기"
+        );
     }
 }
 

--- a/src/main/java/roomescape/reservation/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/MyReservationResponse.java
@@ -1,0 +1,19 @@
+package roomescape.reservation;
+
+public record MyReservationResponse(
+        Long id,
+        String theme,
+        String date,
+        String time,
+        String status
+) {
+    static MyReservationResponse from(Reservation reservation) {
+        return new MyReservationResponse(
+                reservation.getId(),
+                reservation.getTheme().getName(),
+                reservation.getDate(),
+                reservation.getTime().getValue(),
+                "예약");
+    }
+}
+

--- a/src/main/java/roomescape/reservation/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/MyReservationResponse.java
@@ -20,13 +20,13 @@ public record MyReservationResponse(
     }
 
     public static MyReservationResponse from(WaitingWithRank waitingWithRank) {
-        Waiting waiting = waitingWithRank.getWaiting();
+        Waiting waiting = waitingWithRank.waiting();
         return new MyReservationResponse(
                 waiting.getId(),
                 waiting.getTheme().getName(),
                 waiting.getDate(),
                 waiting.getTime().getValue(),
-                waitingWithRank.getRank() + 1 + "번째 예약대기"
+                waitingWithRank.rank() + "번째 예약대기"
         );
     }
 }

--- a/src/main/java/roomescape/reservation/Reservation.java
+++ b/src/main/java/roomescape/reservation/Reservation.java
@@ -25,12 +25,7 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    public Reservation(Long id, String name, String date, Time time, Theme theme) {
-        this.id = id;
-        this.name = name;
-        this.date = date;
-        this.time = time;
-        this.theme = theme;
+    public Reservation() {
     }
 
     public Reservation(String name, String date, Time time, Theme theme, Member member) {
@@ -39,10 +34,6 @@ public class Reservation {
         this.time = time;
         this.theme = theme;
         this.member = member;
-    }
-
-    public Reservation() {
-
     }
 
     public Long getId() {
@@ -63,5 +54,9 @@ public class Reservation {
 
     public Theme getTheme() {
         return theme;
+    }
+
+    public Member getMember() {
+        return member;
     }
 }

--- a/src/main/java/roomescape/reservation/Reservation.java
+++ b/src/main/java/roomescape/reservation/Reservation.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import roomescape.member.Member;
 import roomescape.theme.Theme;
 import roomescape.time.Time;
 
@@ -21,6 +22,8 @@ public class Reservation {
     private Time time;
     @ManyToOne(fetch = FetchType.LAZY)
     private Theme theme;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
     public Reservation(Long id, String name, String date, Time time, Theme theme) {
         this.id = id;
@@ -30,11 +33,12 @@ public class Reservation {
         this.theme = theme;
     }
 
-    public Reservation(String name, String date, Time time, Theme theme) {
+    public Reservation(String name, String date, Time time, Theme theme, Member member) {
         this.name = name;
         this.date = date;
         this.time = time;
         this.theme = theme;
+        this.member = member;
     }
 
     public Reservation() {

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -33,9 +33,7 @@ public class ReservationController {
 
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
-        reservationRequest.checkName(loginMember.name());
         ReservationResponse reservation = reservationService.save(reservationRequest, loginMember.email());
-
         return ResponseEntity.created(URI.create("/reservations/" + reservation.id())).body(reservation);
     }
 

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -33,7 +33,7 @@ public class ReservationController {
 
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
-        ReservationResponse reservation = reservationService.save(reservationRequest, loginMember.email());
+        ReservationResponse reservation = reservationService.create(reservationRequest, loginMember.email());
         return ResponseEntity.created(URI.create("/reservations/" + reservation.id())).body(reservation);
     }
 

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -26,7 +26,7 @@ public class ReservationController {
     }
 
     @GetMapping("/reservations-mine")
-    public ResponseEntity<List<MyReservationResponse>> readAllWithMember(LoginMember loginMember) {
+    public ResponseEntity<List<MyReservationResponse>> readAllByMember(LoginMember loginMember) {
         List<MyReservationResponse> response = reservationService.readAllByMember(loginMember.email());
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -36,7 +36,7 @@ public class ReservationController {
         reservationRequest.checkName(loginMember.name());
         ReservationResponse reservation = reservationService.save(reservationRequest, loginMember.email());
 
-        return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
+        return ResponseEntity.created(URI.create("/reservations/" + reservation.id())).body(reservation);
     }
 
     @DeleteMapping("/reservations/{id}")

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -25,6 +25,12 @@ public class ReservationController {
         return reservationService.findAll();
     }
 
+    @GetMapping("/reservations-mine")
+    public ResponseEntity<List<MyReservationResponse>> readAllWithMember(LoginMember loginMember) {
+        List<MyReservationResponse> response = reservationService.readAllByMember(loginMember.email());
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
         reservationRequest.checkName(loginMember.name());

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -28,7 +28,7 @@ public class ReservationController {
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
         reservationRequest.checkName(loginMember.name());
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+        ReservationResponse reservation = reservationService.save(reservationRequest, loginMember.email());
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/roomescape/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/ReservationRepository.java
@@ -2,7 +2,7 @@ package roomescape.reservation;
 
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 import roomescape.member.Member;
 import roomescape.theme.Theme;
@@ -10,13 +10,13 @@ import roomescape.time.Time;
 
 public interface ReservationRepository extends CrudRepository<Reservation, Long> {
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.member WHERE r.date = :date AND r.time = :time AND r.theme = :theme")
+    @EntityGraph(attributePaths = {"member"})
     Optional<Reservation> findWithMemberByDateAndTimeAndTheme(String date, Time time, Theme theme);
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time")
+    @EntityGraph(attributePaths = {"time", "theme"})
     List<Reservation> findAll();
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time WHERE r.member = :member")
+    @EntityGraph(attributePaths = {"time", "theme"})
     List<Reservation> findByMember(Member member);
 
     List<Reservation> findByDateAndThemeId(String date, Long themeId);

--- a/src/main/java/roomescape/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/ReservationRepository.java
@@ -4,8 +4,12 @@ import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import roomescape.member.Member;
+import roomescape.theme.Theme;
+import roomescape.time.Time;
 
 public interface ReservationRepository extends CrudRepository<Reservation, Long> {
+    boolean existsByDateAndTimeAndThemeAndMember(String date, Time time, Theme theme, Member member);
+
     @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time")
     List<Reservation> findAll();
 

--- a/src/main/java/roomescape/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/ReservationRepository.java
@@ -9,6 +9,7 @@ public interface ReservationRepository extends CrudRepository<Reservation, Long>
     @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time")
     List<Reservation> findAll();
 
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time WHERE r.member = :member")
     List<Reservation> findByMember(Member member);
 
     List<Reservation> findByDateAndThemeId(String date, Long themeId);

--- a/src/main/java/roomescape/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/ReservationRepository.java
@@ -3,10 +3,13 @@ package roomescape.reservation;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import roomescape.member.Member;
 
 public interface ReservationRepository extends CrudRepository<Reservation, Long> {
     @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time")
     List<Reservation> findAll();
+
+    List<Reservation> findByMember(Member member);
 
     List<Reservation> findByDateAndThemeId(String date, Long themeId);
 }

--- a/src/main/java/roomescape/reservation/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/ReservationRepository.java
@@ -1,6 +1,7 @@
 package roomescape.reservation;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import roomescape.member.Member;
@@ -8,7 +9,9 @@ import roomescape.theme.Theme;
 import roomescape.time.Time;
 
 public interface ReservationRepository extends CrudRepository<Reservation, Long> {
-    boolean existsByDateAndTimeAndThemeAndMember(String date, Time time, Theme theme, Member member);
+
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.member WHERE r.date = :date AND r.time = :time AND r.theme = :theme")
+    Optional<Reservation> findWithMemberByDateAndTimeAndTheme(String date, Time time, Theme theme);
 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.theme JOIN FETCH r.time")
     List<Reservation> findAll();

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -1,43 +1,17 @@
 package roomescape.reservation;
 
-public class ReservationRequest {
-    private String name;
-    private String date;
-    private Long theme;
-    private Long time;
-
-    public ReservationRequest(String name, String date, Long theme, Long time) {
+public record ReservationRequest(
+        String name,
+        String date,
+        Long theme,
+        Long time
+) {
+    public ReservationRequest {
         validateDate(date);
         validateTheme(theme);
         validateTime(time);
-        this.name = name;
-        this.date = date;
-        this.theme = theme;
-        this.time = time;
     }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public Long getTheme() {
-        return theme;
-    }
-
-    public Long getTime() {
-        return time;
-    }
-
-    public void checkName(String name) {
-        if (this.name == null) {
-            this.name = name;
-        }
-    }
-
+    
     private void validateDate(String date) {
         if (date == null) {
             throw new IllegalArgumentException("Invalid date");

--- a/src/main/java/roomescape/reservation/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/ReservationResponse.java
@@ -1,37 +1,19 @@
 package roomescape.reservation;
 
-public class ReservationResponse {
-    private Long id;
-    private String name;
-    private String theme;
-    private String date;
-    private String time;
-
-    public ReservationResponse(Long id, String name, String theme, String date, String time) {
-        this.id = id;
-        this.name = name;
-        this.theme = theme;
-        this.date = date;
-        this.time = time;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getTheme() {
-        return theme;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public String getTime() {
-        return time;
+public record ReservationResponse(
+        Long id,
+        String name,
+        String theme,
+        String date,
+        String time
+) {
+    public static ReservationResponse from(Reservation reservation) {
+        return new ReservationResponse(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getTheme().getName(),
+                reservation.getDate(),
+                reservation.getTime().getValue()
+        );
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -37,32 +37,37 @@ public class ReservationService {
         return List.copyOf(Stream.concat(reservations.stream(), waitings.stream()).toList());
     }
 
-    private List<MyReservationResponse> getMemberReservation(Member member) {
+    public List<MyReservationResponse> getMemberReservation(Member member) {
+        return reservationRepository.findByMember(member).stream()
+                .map(MyReservationResponse::from)
+                .toList();
+    }
+
+    public List<MyReservationResponse> getMemberWaiting(Member member) {
         return waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
                 .map(MyReservationResponse::from)
                 .toList();
     }
 
-    private List<MyReservationResponse> getMemberWaiting(Member member) {
-        return waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
-                .map(MyReservationResponse::from)
-                .toList();
-    }
-
-    public ReservationResponse save(ReservationRequest reservationRequest, String email) {
+    public ReservationResponse create(ReservationRequest reservationRequest, String email) {
         Member member = memberRepository.findByEmailOrThrow(email);
         Time time = timeRepository.findByIdOrThrow(reservationRequest.time());
         Theme theme = themeRepository.findByIdOrThrow(reservationRequest.theme());
+        String name = getNonNullName(reservationRequest.name(), member.getName());
 
-        Reservation reservation = new Reservation(
-                Optional.ofNullable(reservationRequest.name()).orElse(member.getName()), reservationRequest.date(),
-                time, theme, member);
-
-        Reservation savedReservation = reservationRepository.save(reservation);
-
-        return ReservationResponse.from(savedReservation);
+        Reservation reservation = save(name, reservationRequest.date(), time, theme, member);
+        return ReservationResponse.from(reservation);
     }
-    
+
+    public Reservation save(String name, String date, Time time, Theme theme, Member member) {
+        Reservation reservation = new Reservation(name, date, time, theme, member);
+        return reservationRepository.save(reservation);
+    }
+
+    private String getNonNullName(String value, String other) {
+        return Optional.ofNullable(value).orElse(other);
+    }
+
     public void deleteById(Long id) {
         reservationRepository.deleteById(id);
     }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -46,9 +46,7 @@ public class ReservationService {
                 theme, member);
         Reservation savedReservation = reservationRepository.save(reservation);
 
-        return new ReservationResponse(savedReservation.getId(), savedReservation.getName(),
-                savedReservation.getTheme().getName(), savedReservation.getDate(),
-                savedReservation.getTime().getValue());
+        return ReservationResponse.from(savedReservation);
     }
 
     public void deleteById(Long id) {
@@ -57,8 +55,7 @@ public class ReservationService {
 
     public List<ReservationResponse> findAll() {
         return reservationRepository.findAll().stream()
-                .map(it -> new ReservationResponse(it.getId(), it.getName(), it.getTheme().getName(), it.getDate(),
-                        it.getTime().getValue()))
+                .map(ReservationResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -24,6 +24,17 @@ public class ReservationService {
         this.memberRepository = memberRepository;
     }
 
+    public List<MyReservationResponse> readAllByMember(String email) {
+        return findAllByMember(email).stream()
+                .map(MyReservationResponse::from)
+                .toList();
+    }
+
+    public List<Reservation> findAllByMember(String email) {
+        Member member = memberRepository.findByEmailOrThrow(email);
+        return reservationRepository.findByMember(member);
+    }
+
     public ReservationResponse save(ReservationRequest reservationRequest, String email) {
         Member member = memberRepository.findByEmailOrThrow(email);
         Time time = timeRepository.findByIdOrThrow(reservationRequest.getTime());

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -2,6 +2,8 @@ package roomescape.reservation;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import roomescape.member.Member;
+import roomescape.member.MemberRepository;
 import roomescape.theme.Theme;
 import roomescape.theme.ThemeRepository;
 import roomescape.time.Time;
@@ -12,20 +14,22 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final TimeRepository timeRepository;
     private final ThemeRepository themeRepository;
+    private final MemberRepository memberRepository;
 
     public ReservationService(ReservationRepository reservationRepository, TimeRepository timeRepository,
-                              ThemeRepository themeRepository) {
+                              ThemeRepository themeRepository, MemberRepository memberRepository) {
         this.reservationRepository = reservationRepository;
         this.timeRepository = timeRepository;
         this.themeRepository = themeRepository;
+        this.memberRepository = memberRepository;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
+    public ReservationResponse save(ReservationRequest reservationRequest, String email) {
+        Member member = memberRepository.findByEmailOrThrow(email);
         Time time = timeRepository.findByIdOrThrow(reservationRequest.getTime());
-        Theme theme = themeRepository.findByIdOrThrow(reservationRequest.getTime());
+        Theme theme = themeRepository.findByIdOrThrow(reservationRequest.getTheme());
         Reservation reservation = new Reservation(reservationRequest.getName(), reservationRequest.getDate(), time,
-                theme);
-
+                theme, member);
         Reservation savedReservation = reservationRepository.save(reservation);
 
         return new ReservationResponse(savedReservation.getId(), savedReservation.getName(),

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package roomescape.reservation;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
 import roomescape.member.Member;
@@ -40,10 +41,13 @@ public class ReservationService {
 
     public ReservationResponse save(ReservationRequest reservationRequest, String email) {
         Member member = memberRepository.findByEmailOrThrow(email);
-        Time time = timeRepository.findByIdOrThrow(reservationRequest.getTime());
-        Theme theme = themeRepository.findByIdOrThrow(reservationRequest.getTheme());
-        Reservation reservation = new Reservation(reservationRequest.getName(), reservationRequest.getDate(), time,
-                theme, member);
+        Time time = timeRepository.findByIdOrThrow(reservationRequest.time());
+        Theme theme = themeRepository.findByIdOrThrow(reservationRequest.theme());
+
+        Reservation reservation = new Reservation(
+                Optional.ofNullable(reservationRequest.name()).orElse(member.getName()), reservationRequest.date(),
+                time, theme, member);
+
         Reservation savedReservation = reservationRepository.save(reservation);
 
         return ReservationResponse.from(savedReservation);

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package roomescape.reservation;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
 import roomescape.member.Member;
 import roomescape.member.MemberRepository;
@@ -8,6 +9,7 @@ import roomescape.theme.Theme;
 import roomescape.theme.ThemeRepository;
 import roomescape.time.Time;
 import roomescape.time.TimeRepository;
+import roomescape.waiting.WaitingRepository;
 
 @Service
 public class ReservationService {
@@ -15,24 +17,25 @@ public class ReservationService {
     private final TimeRepository timeRepository;
     private final ThemeRepository themeRepository;
     private final MemberRepository memberRepository;
+    private final WaitingRepository waitingRepository;
 
     public ReservationService(ReservationRepository reservationRepository, TimeRepository timeRepository,
-                              ThemeRepository themeRepository, MemberRepository memberRepository) {
+                              ThemeRepository themeRepository, MemberRepository memberRepository,
+                              WaitingRepository waitingRepository) {
         this.reservationRepository = reservationRepository;
         this.timeRepository = timeRepository;
         this.themeRepository = themeRepository;
         this.memberRepository = memberRepository;
+        this.waitingRepository = waitingRepository;
     }
 
     public List<MyReservationResponse> readAllByMember(String email) {
-        return findAllByMember(email).stream()
-                .map(MyReservationResponse::from)
-                .toList();
-    }
-
-    public List<Reservation> findAllByMember(String email) {
         Member member = memberRepository.findByEmailOrThrow(email);
-        return reservationRepository.findByMember(member);
+        List<MyReservationResponse> reservations = reservationRepository.findByMember(member).stream()
+                .map(MyReservationResponse::from).toList();
+        List<MyReservationResponse> waitings = waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
+                .map(MyReservationResponse::from).toList();
+        return List.copyOf(Stream.concat(reservations.stream(), waitings.stream()).toList());
     }
 
     public ReservationResponse save(ReservationRequest reservationRequest, String email) {

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -34,7 +34,7 @@ public class ReservationService {
         Member member = memberRepository.findByEmailOrThrow(email);
         List<MyReservationResponse> reservations = getMemberReservation(member);
         List<MyReservationResponse> waitings = getMemberWaiting(member);
-        return List.copyOf(Stream.concat(reservations.stream(), waitings.stream()).toList());
+        return Stream.concat(reservations.stream(), waitings.stream()).toList();
     }
 
     public List<MyReservationResponse> getMemberReservation(Member member) {

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -32,11 +32,21 @@ public class ReservationService {
 
     public List<MyReservationResponse> readAllByMember(String email) {
         Member member = memberRepository.findByEmailOrThrow(email);
-        List<MyReservationResponse> reservations = reservationRepository.findByMember(member).stream()
-                .map(MyReservationResponse::from).toList();
-        List<MyReservationResponse> waitings = waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
-                .map(MyReservationResponse::from).toList();
+        List<MyReservationResponse> reservations = getMemberReservation(member);
+        List<MyReservationResponse> waitings = getMemberWaiting(member);
         return List.copyOf(Stream.concat(reservations.stream(), waitings.stream()).toList());
+    }
+
+    private List<MyReservationResponse> getMemberReservation(Member member) {
+        return waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
+                .map(MyReservationResponse::from)
+                .toList();
+    }
+
+    private List<MyReservationResponse> getMemberWaiting(Member member) {
+        return waitingRepository.findAllWithRankByMemberId(member.getId()).stream()
+                .map(MyReservationResponse::from)
+                .toList();
     }
 
     public ReservationResponse save(ReservationRequest reservationRequest, String email) {
@@ -52,7 +62,7 @@ public class ReservationService {
 
         return ReservationResponse.from(savedReservation);
     }
-
+    
     public void deleteById(Long id) {
         reservationRepository.deleteById(id);
     }

--- a/src/main/java/roomescape/waiting/Waiting.java
+++ b/src/main/java/roomescape/waiting/Waiting.java
@@ -1,0 +1,57 @@
+package roomescape.waiting;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import roomescape.member.Member;
+import roomescape.theme.Theme;
+import roomescape.time.Time;
+
+@Entity
+public class Waiting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String date;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Time time;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Theme theme;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public Waiting() {
+    }
+
+    public Waiting(String name, String date, Time time, Theme theme, Member member) {
+        this.name = name;
+        this.date = date;
+        this.time = time;
+        this.theme = theme;
+        this.member = member;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public Time getTime() {
+        return time;
+    }
+
+    public Theme getTheme() {
+        return theme;
+    }
+}

--- a/src/main/java/roomescape/waiting/WaitingController.java
+++ b/src/main/java/roomescape/waiting/WaitingController.java
@@ -1,0 +1,24 @@
+package roomescape.waiting;
+
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.auth.LoginMember;
+
+@RestController
+public class WaitingController {
+    private final WaitingService waitingService;
+
+    public WaitingController(WaitingService waitingService) {
+        this.waitingService = waitingService;
+    }
+
+    @PostMapping("/waitings")
+    public ResponseEntity<WaitingResponse> create(@RequestBody WaitingRequest waitingRequest,
+                                                  LoginMember loginMember) {
+        WaitingResponse waitingResponse = waitingService.create(waitingRequest, loginMember.email());
+        return ResponseEntity.created(URI.create("/waitings/" + waitingResponse.id())).body(waitingResponse);
+    }
+}

--- a/src/main/java/roomescape/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/WaitingRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import roomescape.member.Member;
+import roomescape.theme.Theme;
+import roomescape.time.Time;
 
 @Repository
 public interface WaitingRepository extends CrudRepository<Waiting, Long> {
@@ -18,4 +21,6 @@ public interface WaitingRepository extends CrudRepository<Waiting, Long> {
             "FROM Waiting w " +
             "WHERE w.member.id = :memberId")
     List<WaitingWithRank> findAllWithRankByMemberId(Long memberId);
+
+    boolean existsByDateAndTimeAndThemeAndMember(String date, Time time, Theme theme, Member member);
 }

--- a/src/main/java/roomescape/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/WaitingRepository.java
@@ -1,8 +1,21 @@
 package roomescape.waiting;
 
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WaitingRepository extends CrudRepository<Waiting, Long> {
+    @Query("SELECT new roomescape.waiting.WaitingWithRank(" +
+            "    w, " +
+            "    (SELECT COUNT(w2) " +
+            "     FROM Waiting w2 " +
+            "     WHERE w2.theme = w.theme " +
+            "       AND w2.date = w.date " +
+            "       AND w2.time = w.time " +
+            "       AND w2.id < w.id)) " +
+            "FROM Waiting w " +
+            "WHERE w.member.id = :memberId")
+    List<WaitingWithRank> findAllWithRankByMemberId(Long memberId);
 }

--- a/src/main/java/roomescape/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/WaitingRepository.java
@@ -1,0 +1,8 @@
+package roomescape.waiting;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WaitingRepository extends CrudRepository<Waiting, Long> {
+}

--- a/src/main/java/roomescape/waiting/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/WaitingRepository.java
@@ -17,7 +17,7 @@ public interface WaitingRepository extends CrudRepository<Waiting, Long> {
             "     WHERE w2.theme = w.theme " +
             "       AND w2.date = w.date " +
             "       AND w2.time = w.time " +
-            "       AND w2.id < w.id)) " +
+            "       AND w2.id <= w.id)) " +
             "FROM Waiting w " +
             "WHERE w.member.id = :memberId")
     List<WaitingWithRank> findAllWithRankByMemberId(Long memberId);

--- a/src/main/java/roomescape/waiting/WaitingRequest.java
+++ b/src/main/java/roomescape/waiting/WaitingRequest.java
@@ -1,0 +1,32 @@
+package roomescape.waiting;
+
+public record WaitingRequest(
+        String name,
+        String date,
+        Long timeId,
+        Long themeId
+) {
+    public WaitingRequest {
+        validateDate(date);
+        validateTime(timeId);
+        validateTheme(themeId);
+    }
+
+    private void validateDate(String date) {
+        if (date == null) {
+            throw new IllegalArgumentException("Invalid date");
+        }
+    }
+
+    private void validateTime(Long time) {
+        if (time == null) {
+            throw new IllegalArgumentException("Invalid time");
+        }
+    }
+
+    private void validateTheme(Long theme) {
+        if (theme == null) {
+            throw new IllegalArgumentException("Invalid theme");
+        }
+    }
+}

--- a/src/main/java/roomescape/waiting/WaitingResponse.java
+++ b/src/main/java/roomescape/waiting/WaitingResponse.java
@@ -1,0 +1,14 @@
+package roomescape.waiting;
+
+public record WaitingResponse(
+        Long id,
+        String name,
+        String date,
+        String time,
+        String theme
+) {
+    public static WaitingResponse from(Waiting waiting) {
+        return new WaitingResponse(waiting.getId(), waiting.getName(), waiting.getDate(), waiting.getTime().getValue(),
+                waiting.getTheme().getName());
+    }
+}

--- a/src/main/java/roomescape/waiting/WaitingService.java
+++ b/src/main/java/roomescape/waiting/WaitingService.java
@@ -24,11 +24,26 @@ public class WaitingService {
     }
 
     public WaitingResponse create(WaitingRequest waitingRequest, String memberEmail) {
+        // 예약 할 수 있으면서 대기하는 경우 에외
         Member member = memberRepository.findByEmailOrThrow(memberEmail);
         Time time = timeRepository.findByIdOrThrow(waitingRequest.timeId());
         Theme theme = themeRepository.findByIdOrThrow(waitingRequest.themeId());
+
+        validateDuplicateWaiting(waitingRequest.date(), time, theme, member);
+
         Waiting waiting = new Waiting(waitingRequest.name(), waitingRequest.date(), time, theme, member);
         Waiting savedWaiting = waitingRepository.save(waiting);
         return WaitingResponse.from(savedWaiting);
+    }
+
+    public void validateDuplicateWaiting(String date, Time time, Theme theme, Member member) {
+        if (existsByDateAndTimeAndThemeAndMember(date, time, theme, member)) {
+            throw new IllegalArgumentException(
+                    String.format("Waiting already exist %s, %s, %s", date, time.getValue(), theme.getName()));
+        }
+    }
+
+    public boolean existsByDateAndTimeAndThemeAndMember(String date, Time time, Theme theme, Member member) {
+        return waitingRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
     }
 }

--- a/src/main/java/roomescape/waiting/WaitingService.java
+++ b/src/main/java/roomescape/waiting/WaitingService.java
@@ -41,14 +41,14 @@ public class WaitingService {
         return WaitingResponse.from(savedWaiting);
     }
 
-    public void validateDuplicateWaiting(String date, Time time, Theme theme, Member member) {
+    private void validateDuplicateWaiting(String date, Time time, Theme theme, Member member) {
         if (hasExistingWaiting(date, time, theme, member)) {
             throw new IllegalArgumentException(
                     String.format("Waiting already exist %s, %s, %s", date, time.getValue(), theme.getName()));
         }
     }
 
-    public void validateReservationExistsAndNotOwnedByMember(String date, Time time, Theme theme, Member member) {
+    private void validateReservationExistsAndNotOwnedByMember(String date, Time time, Theme theme, Member member) {
         Reservation reservation = reservationRepository.findWithMemberByDateAndTimeAndTheme(date, time, theme)
                 .orElseThrow(() -> new IllegalArgumentException(
                         String.format("Reservation is available %s, %s, %s", date, time.getValue(), theme.getName())));

--- a/src/main/java/roomescape/waiting/WaitingService.java
+++ b/src/main/java/roomescape/waiting/WaitingService.java
@@ -3,6 +3,8 @@ package roomescape.waiting;
 import org.springframework.stereotype.Service;
 import roomescape.member.Member;
 import roomescape.member.MemberRepository;
+import roomescape.reservation.Reservation;
+import roomescape.reservation.ReservationRepository;
 import roomescape.theme.Theme;
 import roomescape.theme.ThemeRepository;
 import roomescape.time.Time;
@@ -14,21 +16,24 @@ public class WaitingService {
     private final TimeRepository timeRepository;
     private final ThemeRepository themeRepository;
     private final MemberRepository memberRepository;
+    private final ReservationRepository reservationRepository;
 
     public WaitingService(WaitingRepository waitingRepository, TimeRepository timeRepository,
-                          ThemeRepository themeRepository, MemberRepository memberRepository) {
+                          ThemeRepository themeRepository, MemberRepository memberRepository,
+                          ReservationRepository reservationRepository) {
         this.waitingRepository = waitingRepository;
         this.timeRepository = timeRepository;
         this.themeRepository = themeRepository;
         this.memberRepository = memberRepository;
+        this.reservationRepository = reservationRepository;
     }
 
     public WaitingResponse create(WaitingRequest waitingRequest, String memberEmail) {
-        // 예약 할 수 있으면서 대기하는 경우 에외
         Member member = memberRepository.findByEmailOrThrow(memberEmail);
         Time time = timeRepository.findByIdOrThrow(waitingRequest.timeId());
         Theme theme = themeRepository.findByIdOrThrow(waitingRequest.themeId());
 
+        validateReservationExistsAndNotOwnedByMember(waitingRequest.date(), time, theme, member);
         validateDuplicateWaiting(waitingRequest.date(), time, theme, member);
 
         Waiting waiting = new Waiting(waitingRequest.name(), waitingRequest.date(), time, theme, member);
@@ -37,13 +42,24 @@ public class WaitingService {
     }
 
     public void validateDuplicateWaiting(String date, Time time, Theme theme, Member member) {
-        if (existsByDateAndTimeAndThemeAndMember(date, time, theme, member)) {
+        if (hasExistingWaiting(date, time, theme, member)) {
             throw new IllegalArgumentException(
                     String.format("Waiting already exist %s, %s, %s", date, time.getValue(), theme.getName()));
         }
     }
 
-    public boolean existsByDateAndTimeAndThemeAndMember(String date, Time time, Theme theme, Member member) {
+    public void validateReservationExistsAndNotOwnedByMember(String date, Time time, Theme theme, Member member) {
+        Reservation reservation = reservationRepository.findWithMemberByDateAndTimeAndTheme(date, time, theme)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Reservation is available %s, %s, %s", date, time.getValue(), theme.getName())));
+
+        if (reservation.getMember().equals(member)) {
+            throw new IllegalArgumentException(
+                    String.format("Reservation already exist %s, %s, %s", date, time.getValue(), theme.getName()));
+        }
+    }
+
+    public boolean hasExistingWaiting(String date, Time time, Theme theme, Member member) {
         return waitingRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
     }
 }

--- a/src/main/java/roomescape/waiting/WaitingService.java
+++ b/src/main/java/roomescape/waiting/WaitingService.java
@@ -1,0 +1,34 @@
+package roomescape.waiting;
+
+import org.springframework.stereotype.Service;
+import roomescape.member.Member;
+import roomescape.member.MemberRepository;
+import roomescape.theme.Theme;
+import roomescape.theme.ThemeRepository;
+import roomescape.time.Time;
+import roomescape.time.TimeRepository;
+
+@Service
+public class WaitingService {
+    private final WaitingRepository waitingRepository;
+    private final TimeRepository timeRepository;
+    private final ThemeRepository themeRepository;
+    private final MemberRepository memberRepository;
+
+    public WaitingService(WaitingRepository waitingRepository, TimeRepository timeRepository,
+                          ThemeRepository themeRepository, MemberRepository memberRepository) {
+        this.waitingRepository = waitingRepository;
+        this.timeRepository = timeRepository;
+        this.themeRepository = themeRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public WaitingResponse create(WaitingRequest waitingRequest, String memberEmail) {
+        Member member = memberRepository.findByEmailOrThrow(memberEmail);
+        Time time = timeRepository.findByIdOrThrow(waitingRequest.timeId());
+        Theme theme = themeRepository.findByIdOrThrow(waitingRequest.themeId());
+        Waiting waiting = new Waiting(waitingRequest.name(), waitingRequest.date(), time, theme, member);
+        Waiting savedWaiting = waitingRepository.save(waiting);
+        return WaitingResponse.from(savedWaiting);
+    }
+}

--- a/src/main/java/roomescape/waiting/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/WaitingWithRank.java
@@ -1,19 +1,7 @@
 package roomescape.waiting;
 
-public class WaitingWithRank {
-    Waiting waiting;
-    Long rank;
-
-    public WaitingWithRank(Waiting waiting, Long rank) {
-        this.waiting = waiting;
-        this.rank = rank;
-    }
-
-    public Waiting getWaiting() {
-        return waiting;
-    }
-
-    public Long getRank() {
-        return rank;
-    }
+public record WaitingWithRank(
+        Waiting waiting,
+        Long rank
+) {
 }

--- a/src/main/java/roomescape/waiting/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/WaitingWithRank.java
@@ -1,0 +1,19 @@
+package roomescape.waiting;
+
+public class WaitingWithRank {
+    Waiting waiting;
+    Long rank;
+
+    public WaitingWithRank(Waiting waiting, Long rank) {
+        this.waiting = waiting;
+        this.rank = rank;
+    }
+
+    public Waiting getWaiting() {
+        return waiting;
+    }
+
+    public Long getRank() {
+        return rank;
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -15,7 +15,7 @@ VALUES ('10:00'),
        ('18:00'),
        ('20:00');
 
-INSERT INTO reservation (name, date, time_id, theme_id)
-VALUES ('어드민', '2024-03-01', 1, 1),
-       ('어드민', '2024-03-01', 2, 2),
-       ('어드민', '2024-03-01', 3, 3);
+INSERT INTO reservation (name, date, time_id, theme_id, member_id)
+VALUES ('어드민', '2024-03-01', 1, 1, 1),
+       ('어드민', '2024-03-01', 2, 2, 1),
+       ('어드민', '2024-03-01', 3, 3, 1);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -7,10 +7,12 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.MyReservationResponse;
 import roomescape.reservation.ReservationResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -112,5 +114,19 @@ public class MissionStepTest {
                 .get("/admin")
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    @Test
+    void 오단계() {
+        String adminToken = createToken("admin@email.com", "password");
+
+        List<MyReservationResponse> reservations = RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/reservations-mine")
+                .then().log().all()
+                .statusCode(200)
+                .extract().jsonPath().getList(".", MyReservationResponse.class);
+
+        assertThat(reservations).hasSize(3);
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -66,7 +66,7 @@ public class MissionStepTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(201);
-        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+        assertThat(response.as(ReservationResponse.class).name()).isEqualTo("어드민");
 
         params.put("name", "브라운");
 
@@ -79,7 +79,7 @@ public class MissionStepTest {
                 .extract();
 
         assertThat(adminResponse.statusCode()).isEqualTo(201);
-        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+        assertThat(adminResponse.as(ReservationResponse.class).name()).isEqualTo("브라운");
     }
 
     private String createToken(String email, String password) {

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.reservation.MyReservationResponse;
 import roomescape.reservation.ReservationResponse;
+import roomescape.waiting.WaitingResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -128,5 +129,45 @@ public class MissionStepTest {
                 .extract().jsonPath().getList(".", MyReservationResponse.class);
 
         assertThat(reservations).hasSize(3);
+    }
+
+    @Test
+    void 육단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("timeId", "1");
+        params.put("themeId", "1");
+
+        // 예약 대기 생성
+        WaitingResponse waiting = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", brownToken)
+                .contentType(ContentType.JSON)
+                .post("/waitings")
+                .then().log().all()
+                .statusCode(201)
+                .extract().as(WaitingResponse.class);
+
+        // 내 예약 목록 조회
+        List<MyReservationResponse> myReservations = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", brownToken)
+                .contentType(ContentType.JSON)
+                .get("/reservations-mine")
+                .then().log().all()
+                .statusCode(200)
+                .extract().jsonPath().getList(".", MyReservationResponse.class);
+
+        // 예약 대기 상태 확인
+        String status = myReservations.stream()
+                .filter(it -> it.id() == waiting.id())
+                .filter(it -> !it.status().equals("예약"))
+                .findFirst()
+                .map(it -> it.status())
+                .orElse(null);
+
+        assertThat(status).isEqualTo("1번째 예약대기");
     }
 }

--- a/src/test/java/roomescape/reservation/CreateReservationTest.java
+++ b/src/test/java/roomescape/reservation/CreateReservationTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-class CreateReservations {
-    
+class CreateReservationTest {
+
     @Test
     void 로그인_상태에서_예약자명이_존재하지않는_경우_로그인_정보명으로_예약된다() {
         //given
@@ -26,7 +26,7 @@ class CreateReservations {
                 ReservationResponse.class);
 
         //then
-        assertThat(reservationResponse.getName()).isEqualTo("어드민");
+        assertThat(reservationResponse.name()).isEqualTo("어드민");
     }
 
     @Test
@@ -40,7 +40,7 @@ class CreateReservations {
                 ReservationResponse.class);
 
         //then
-        assertThat(reservationResponse.getName()).isEqualTo("브라운");
+        assertThat(reservationResponse.name()).isEqualTo("브라운");
     }
 
     @Test

--- a/src/test/java/roomescape/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/ReservationRepositoryTest.java
@@ -1,0 +1,63 @@
+package roomescape.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import roomescape.member.Member;
+import roomescape.member.MemberRepository;
+import roomescape.theme.Theme;
+import roomescape.theme.ThemeRepository;
+import roomescape.time.Time;
+import roomescape.time.TimeRepository;
+
+@DataJpaTest
+class ReservationRepositoryTest {
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private TimeRepository timeRepository;
+    @Autowired
+    private ThemeRepository themeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private String date = "2024-03-01";
+    private Time time;
+    private Theme theme;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        time = new Time("10:00");
+        theme = new Theme("테마1", "테마1입니다.");
+        member = new Member("admin", "admin@email.com", "password", "ADMIN");
+        timeRepository.save(time);
+        themeRepository.save(theme);
+        memberRepository.save(member);
+    }
+
+    @Test
+    void 해당_날짜_시간_테마에_대한_본인의_예약이_존재하지_않는_경우_거짓을_반환한다() {
+        // when
+        boolean exists = reservationRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 해당_날짜_시간_테마에_대한_본인의_예약이_존재하는_경우_참을_반환한다() {
+        // given
+        Reservation reservation = new Reservation(member.getName(), date, time, theme, member);
+        reservationRepository.save(reservation);
+
+        // when
+        boolean exists = reservationRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+}

--- a/src/test/java/roomescape/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/reservation/ReservationRepositoryTest.java
@@ -2,6 +2,7 @@ package roomescape.reservation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,24 +41,27 @@ class ReservationRepositoryTest {
     }
 
     @Test
-    void 해당_날짜_시간_테마에_대한_본인의_예약이_존재하지_않는_경우_거짓을_반환한다() {
+    void 해당_날짜_시간_테마에_대한_예약이_존재하지_않는_경우_조회_결과가_비어있다() {
         // when
-        boolean exists = reservationRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
+        Optional<Reservation> savedReservation = reservationRepository.findWithMemberByDateAndTimeAndTheme(date, time,
+                theme);
 
         // then
-        assertThat(exists).isFalse();
+        assertThat(savedReservation).isEmpty();
     }
 
     @Test
-    void 해당_날짜_시간_테마에_대한_본인의_예약이_존재하는_경우_참을_반환한다() {
+    void 해당_날짜_시간_테마에_대한_예약이_존재_하는_경우_사용자와_함께_조회된다() {
         // given
         Reservation reservation = new Reservation(member.getName(), date, time, theme, member);
         reservationRepository.save(reservation);
 
         // when
-        boolean exists = reservationRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, member);
+        Optional<Reservation> savedReservation = reservationRepository.findWithMemberByDateAndTimeAndTheme(date, time,
+                theme);
 
         // then
-        assertThat(exists).isTrue();
+        assertThat(savedReservation).isNotEmpty();
+        assertThat(savedReservation.get().getMember()).isEqualTo(member);
     }
 }

--- a/src/test/java/roomescape/reservation/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/ReservationServiceTest.java
@@ -16,9 +16,18 @@ class ReservationServiceTest {
     private ReservationService reservationService;
 
     @Test
-    void 추가_쿼리_없이_예약_목록_응답_반환_성공() {
+    void 추가_쿼리_없이_모든_예약_목록_응답_반환_성공() {
         // when
         List<ReservationResponse> reservations = reservationService.findAll();
+
+        // then
+        assertThat(reservations.size()).isEqualTo(3);
+    }
+
+    @Test
+    void 추가_쿼리_없이_내_예약_목록_응답_반환_성공() {
+        // when
+        List<MyReservationResponse> reservations = reservationService.readAllByMember("admin@email.com");
 
         // then
         assertThat(reservations.size()).isEqualTo(3);

--- a/src/test/java/roomescape/waiting/WaitingControllerTest.java
+++ b/src/test/java/roomescape/waiting/WaitingControllerTest.java
@@ -17,42 +17,70 @@ import org.springframework.test.annotation.DirtiesContext;
 class WaitingControllerTest {
 
     @Test
-    void 예약_대기_생성_성공() {
+    void 예약이_존재하며_본인의_예약_및_예약_대기가_존재하지_않는_경우_예약_대기_생성에_성공한다() {
         // given
-        String token = createToken("admin@email.com", "password");
-        Map<String, String> request = createPostWaitingRequest();
+        String brownToken = createToken("brown@email.com", "password");
+        Map<String, String> waitingRequest = createPostWaitingRequest("브라운", "2024-03-01", "1", "1");
 
         // when
-        WaitingResponse response = sendPostWaitingRequest(token, request).as(WaitingResponse.class);
+        ExtractableResponse<Response> response = sendPostWaitingRequest(brownToken, waitingRequest);
+        WaitingResponse waitingResponse = response.as(WaitingResponse.class);
 
         // then
-        assertThat(response.name()).isEqualTo("어드민");
-        assertThat(response.date()).isEqualTo("2024-03-01");
-        assertThat(response.time()).isEqualTo("10:00");
-        assertThat(response.theme()).isEqualTo("테마1");
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(waitingResponse.name()).isEqualTo("브라운");
+        assertThat(waitingResponse.date()).isEqualTo("2024-03-01");
+        assertThat(waitingResponse.time()).isEqualTo("10:00");
+        assertThat(waitingResponse.theme()).isEqualTo("테마1");
     }
 
     @Test
-    void 같은_예약_대기가_존재하는_경우_예약_대기_생성에_실패한다() {
+    void 본인의_예약이_존재하는_경우_예약_대기_생성에_실패한다() {
         // given
-        String token = createToken("admin@email.com", "password");
-        Map<String, String> request = createPostWaitingRequest();
-        ExtractableResponse<Response> response = sendPostWaitingRequest(token, request);
+        String adminToken = createToken("admin@email.com", "password");
+        Map<String, String> waitingRequest = createPostWaitingRequest("어드민", "2024-03-01", "1", "1");
 
         // when
-        ExtractableResponse<Response> duplicateResponse = sendPostWaitingRequest(token, request);
+        ExtractableResponse<Response> response = sendPostWaitingRequest(adminToken, waitingRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void 본인의_예약_대기가_존재하는_경우_예약_대기_생성에_실패한다() {
+        // given
+        String brownToken = createToken("brown@email.com", "password");
+        Map<String, String> waitingRequest = createPostWaitingRequest("어드민", "2024-03-01", "1", "1");
+        sendPostWaitingRequest(brownToken, waitingRequest);
+
+        // when
+        ExtractableResponse<Response> duplicateResponse = sendPostWaitingRequest(brownToken, waitingRequest);
 
         // then
         assertThat(duplicateResponse.statusCode()).isEqualTo(400);
     }
 
-    private Map<String, String> createPostWaitingRequest() {
-        Map<String, String> param = new HashMap<>();
-        param.put("name", "어드민");
-        param.put("date", "2024-03-01");
-        param.put("timeId", "1");
-        param.put("themeId", "1");
-        return param;
+    @Test
+    void 예약이_존재하지_않는_경우_예약_대기_생성에_실패한다() {
+        // given
+        String brownToken = createToken("brown@email.com", "password");
+        Map<String, String> waitingRequest = createPostWaitingRequest("브라운", "2024-03-02", "1", "1");
+
+        // when
+        ExtractableResponse<Response> response = sendPostWaitingRequest(brownToken, waitingRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    private Map<String, String> createPostWaitingRequest(String name, String date, String timeId, String themeId) {
+        Map<String, String> request = new HashMap<>();
+        request.put("name", name);
+        request.put("date", date);
+        request.put("timeId", timeId);
+        request.put("themeId", themeId);
+        return request;
     }
 
     private ExtractableResponse<Response> sendPostWaitingRequest(String token, Map<String, String> param) {

--- a/src/test/java/roomescape/waiting/WaitingControllerTest.java
+++ b/src/test/java/roomescape/waiting/WaitingControllerTest.java
@@ -41,6 +41,34 @@ class WaitingControllerTest {
         assertThat(waitingResponse.theme()).isEqualTo("테마1");
     }
 
+    @Test
+    void 같은_예약_대기가_존재하는_경우_예약_대기_생성에_실패한다() {
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> param = new HashMap<>();
+        param.put("name", "어드민");
+        param.put("date", "2024-03-01");
+        param.put("timeId", "1");
+        param.put("themeId", "1");
+
+        WaitingResponse waitingResponse = RestAssured.given().log().all()
+                .cookie("token", token)
+                .body(param)
+                .contentType(ContentType.JSON)
+                .post("/waitings")
+                .then().log().all()
+                .statusCode(201)
+                .extract().as(WaitingResponse.class);
+
+        RestAssured.given().log().all()
+                .cookie("token", token)
+                .body(param)
+                .contentType(ContentType.JSON)
+                .post("/waitings")
+                .then().log().all()
+                .statusCode(400);
+    }
+
     private String createToken(String email, String password) {
         Map<String, String> params = new HashMap<>();
         params.put("email", email);

--- a/src/test/java/roomescape/waiting/WaitingControllerTest.java
+++ b/src/test/java/roomescape/waiting/WaitingControllerTest.java
@@ -1,0 +1,59 @@
+package roomescape.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class WaitingControllerTest {
+
+    @Test
+    void 예약_대기_생성_성공() {
+        String token = createToken("admin@email.com", "password");
+
+        Map<String, String> param = new HashMap<>();
+        param.put("name", "어드민");
+        param.put("date", "2024-03-01");
+        param.put("timeId", "1");
+        param.put("themeId", "1");
+
+        WaitingResponse waitingResponse = RestAssured.given().log().all()
+                .cookie("token", token)
+                .body(param)
+                .contentType(ContentType.JSON)
+                .post("/waitings")
+                .then().log().all()
+                .statusCode(201)
+                .extract().as(WaitingResponse.class);
+
+        assertThat(waitingResponse.name()).isEqualTo("어드민");
+        assertThat(waitingResponse.date()).isEqualTo("2024-03-01");
+        assertThat(waitingResponse.time()).isEqualTo("10:00");
+        assertThat(waitingResponse.theme()).isEqualTo("테마1");
+    }
+
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+    }
+}

--- a/src/test/java/roomescape/waiting/WaitingControllerTest.java
+++ b/src/test/java/roomescape/waiting/WaitingControllerTest.java
@@ -18,55 +18,50 @@ class WaitingControllerTest {
 
     @Test
     void 예약_대기_생성_성공() {
+        // given
         String token = createToken("admin@email.com", "password");
+        Map<String, String> request = createPostWaitingRequest();
 
-        Map<String, String> param = new HashMap<>();
-        param.put("name", "어드민");
-        param.put("date", "2024-03-01");
-        param.put("timeId", "1");
-        param.put("themeId", "1");
+        // when
+        WaitingResponse response = sendPostWaitingRequest(token, request).as(WaitingResponse.class);
 
-        WaitingResponse waitingResponse = RestAssured.given().log().all()
-                .cookie("token", token)
-                .body(param)
-                .contentType(ContentType.JSON)
-                .post("/waitings")
-                .then().log().all()
-                .statusCode(201)
-                .extract().as(WaitingResponse.class);
-
-        assertThat(waitingResponse.name()).isEqualTo("어드민");
-        assertThat(waitingResponse.date()).isEqualTo("2024-03-01");
-        assertThat(waitingResponse.time()).isEqualTo("10:00");
-        assertThat(waitingResponse.theme()).isEqualTo("테마1");
+        // then
+        assertThat(response.name()).isEqualTo("어드민");
+        assertThat(response.date()).isEqualTo("2024-03-01");
+        assertThat(response.time()).isEqualTo("10:00");
+        assertThat(response.theme()).isEqualTo("테마1");
     }
 
     @Test
     void 같은_예약_대기가_존재하는_경우_예약_대기_생성에_실패한다() {
+        // given
         String token = createToken("admin@email.com", "password");
+        Map<String, String> request = createPostWaitingRequest();
+        ExtractableResponse<Response> response = sendPostWaitingRequest(token, request);
 
+        // when
+        ExtractableResponse<Response> duplicateResponse = sendPostWaitingRequest(token, request);
+
+        // then
+        assertThat(duplicateResponse.statusCode()).isEqualTo(400);
+    }
+
+    private Map<String, String> createPostWaitingRequest() {
         Map<String, String> param = new HashMap<>();
         param.put("name", "어드민");
         param.put("date", "2024-03-01");
         param.put("timeId", "1");
         param.put("themeId", "1");
+        return param;
+    }
 
-        WaitingResponse waitingResponse = RestAssured.given().log().all()
+    private ExtractableResponse<Response> sendPostWaitingRequest(String token, Map<String, String> param) {
+        return RestAssured.given().log().all()
                 .cookie("token", token)
                 .body(param)
                 .contentType(ContentType.JSON)
                 .post("/waitings")
-                .then().log().all()
-                .statusCode(201)
-                .extract().as(WaitingResponse.class);
-
-        RestAssured.given().log().all()
-                .cookie("token", token)
-                .body(param)
-                .contentType(ContentType.JSON)
-                .post("/waitings")
-                .then().log().all()
-                .statusCode(400);
+                .then().log().all().extract();
     }
 
     private String createToken(String email, String password) {

--- a/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
@@ -46,8 +46,9 @@ class WaitingRepositoryTest {
     @Test
     void 순위를_포함한_예약_대기_조회_성공() {
         // given
-        Waiting adminWaiting = new Waiting("어드민", "2024-03-01", time, theme, admin);
-        Waiting brownWaiting = new Waiting("브라운", "2024-03-01", time, theme, brown);
+        String date = "2024-03-01";
+        Waiting adminWaiting = new Waiting(admin.getName(), date, time, theme, admin);
+        Waiting brownWaiting = new Waiting(brown.getName(), date, time, theme, brown);
         waitingRepository.save(adminWaiting);
         waitingRepository.save(brownWaiting);
 
@@ -60,5 +61,28 @@ class WaitingRepositoryTest {
         assertThat(adminWaitings.get(0).rank).isEqualTo(0);
         assertThat(brownWaitings.size()).isEqualTo(1);
         assertThat(brownWaitings.get(0).rank).isEqualTo(1);
+    }
+
+    @Test
+    void 해당_날짜_시간_테마_사용자에_대한_예약_대기가_존재하지_않는_경우_거짓을_반환한다() {
+        // when
+        boolean exists = waitingRepository.existsByDateAndTimeAndThemeAndMember("2024-03-01", time, theme, admin);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 해당_날짜_시간_테마_사용자에_대한_예약_대기가_존재하는_경우_참을_반환한다() {
+        // given
+        String date = "2024-03-01";
+        Waiting waiting = new Waiting(admin.getName(), date, time, theme, admin);
+        waitingRepository.save(waiting);
+
+        // when
+        boolean exists = waitingRepository.existsByDateAndTimeAndThemeAndMember(date, time, theme, admin);
+
+        // then
+        assertThat(exists).isTrue();
     }
 }

--- a/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
@@ -1,0 +1,64 @@
+package roomescape.waiting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import roomescape.member.Member;
+import roomescape.member.MemberRepository;
+import roomescape.theme.Theme;
+import roomescape.theme.ThemeRepository;
+import roomescape.time.Time;
+import roomescape.time.TimeRepository;
+
+@DataJpaTest
+class WaitingRepositoryTest {
+    @Autowired
+    private TimeRepository timeRepository;
+    @Autowired
+    private ThemeRepository themeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    private Member admin;
+    private Member brown;
+    private Time time;
+    private Theme theme;
+
+    @BeforeEach
+    void setUp() {
+        admin = new Member("어드민", "admin@email.com", "password", "ADMIN");
+        brown = new Member("브라운", "brown@email.com", "password", "USER");
+        time = new Time("10:00");
+        theme = new Theme("테마1", "테마1입니다.");
+
+        memberRepository.save(admin);
+        memberRepository.save(brown);
+        timeRepository.save(time);
+        themeRepository.save(theme);
+    }
+
+    @Test
+    void 순위를_포함한_예약_대기_조회_성공() {
+        // given
+        Waiting adminWaiting = new Waiting("어드민", "2024-03-01", time, theme, admin);
+        Waiting brownWaiting = new Waiting("브라운", "2024-03-01", time, theme, brown);
+        waitingRepository.save(adminWaiting);
+        waitingRepository.save(brownWaiting);
+
+        // when
+        List<WaitingWithRank> adminWaitings = waitingRepository.findAllWithRankByMemberId(admin.getId());
+        List<WaitingWithRank> brownWaitings = waitingRepository.findAllWithRankByMemberId(brown.getId());
+
+        // then
+        assertThat(adminWaitings.size()).isEqualTo(1);
+        assertThat(adminWaitings.get(0).rank).isEqualTo(0);
+        assertThat(brownWaitings.size()).isEqualTo(1);
+        assertThat(brownWaitings.get(0).rank).isEqualTo(1);
+    }
+}

--- a/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/WaitingRepositoryTest.java
@@ -58,9 +58,9 @@ class WaitingRepositoryTest {
 
         // then
         assertThat(adminWaitings.size()).isEqualTo(1);
-        assertThat(adminWaitings.get(0).rank).isEqualTo(0);
+        assertThat(adminWaitings.get(0).rank()).isEqualTo(1);
         assertThat(brownWaitings.size()).isEqualTo(1);
-        assertThat(brownWaitings.get(0).rank).isEqualTo(1);
+        assertThat(brownWaitings.get(0).rank()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## 🏃‍♂️ 과정

> 구체적인 방법은 본인이 결정해서 판단합니다.
> 

요구사항을 다시 해석해서 구현하게 되었습니다. 정답을 찾기 어려웠거나 없는 부분이 많아서 추가로 의견을 여쭙게 되었습니다. 
이번 리뷰도 잘 부탁드립니다. 😄 

## **📃 요구사항**

### **내 예약 목록 조회**

이전 3단계 요구사항으로 예약 생성 시에 요청 객체에 이름 필드 값이 존재한다면 해당 이름을, 존재하지 않는다면 로그인한 사용자의 이름을 넣어주었습니다. 이때 해당 예약의 누구의 예약인지 중점을 두었고, `이름과 관계없이 현재 로그인 되어 있는 유저로 연관관계를 맺어주었습니다.`

처음에는 `어드민이 브라운으로 예약을 한다면 이것은 브라운의 예약이 아닐까` 하는 생각도 들었지만, 택배를 시킬 때 배송자 명은 자유롭게 수정 가능하고, 해당 택배 건과 관계가 없으므로 이름은 키가 아니라고 생각하고 구현하게 되었습니다.

로직

- [x]  사용자의 예약 목록 조회 기능 추가
- [x]  사용자의 예약 대기 목록 포함

**예외**

- [x]  파라미터로 Member / Reservation / Theme / Time 를 찾을 수 없는 경우

### **예약 대기 기능**

**로직**

- [x]  예약 대기 생성 기능 추가
- [x]  예약 대기 삭제 기능 추가

**예외**

- [x]  예약 대기를 중복 생성하는 경우
- [x]  예약이 존재하지 않았을 때 예약 대기를 생성하는 경우
- [x]  본인의 예약이 존재하지만 예약 대기를 생성하는 경우

## 🔎 궁금한점

1. 두가지 이상의 도메인의 비즈니스로직이 결합된 기능에 대한 고민
    - 예약 대기 생성: Waiting 을 생성하기 위해서 Reservation 을 검증하는 로직
        1. 시간, 날짜, 테마에 대해서 사용자는 예약 대기를 한번만 생성할 수 있다.
        2. 시간, 날짜, 테마에 대해서 예약이 존재하지 않는 경우 예약 대기를 생성할 수 없다.
        3. 시간, 날짜, 테마에 대해서 본인의 예약이 존재하는 경우 예약 대기를 생성할 수 없다.
        
        Waiting 도메인에서 Reserviaton 테이블에 대해서 검증을 수행하는데 분리가 필요해보입니다. `WaitingService::validateReservationExistsAndNotOwnedByMember`
        
    - 예약 목록 조회: Reservation list 에 Waiting list 도 포함되는 로직
        
        두가지 도메인의 로직이 결합된 해당 메서드는 어디에 두는게 좋을까요?`ReservationService::readAllByMember`
        
    
    추가로 두 도메인의 성격이 매우 비슷하여 Reservation 도메인에 state 필드를 사용해서 Waiting 도메인의 역할을 하면 좋겠다는 생각을 했습니다. 하지만 Reservation 의 테이블과 비즈니스 로직이 많이 커지게 되었는데 레이어를 추가하거나 Reservation 엔티티를 사용하는 WaitingService 와 같이 서비스를 하나 더 두는 방식이 있을 것 같습니다.
    
2. 테스트 시에 초기 데이터(data.sql) 의존에 대한 고민
    
    초기 데이터들을 활용해서 조회 테스트를 작성했을 때 많은 도움을 받았습니다. 하지만 초기 데이터(data.sql)를 모르는 사람이 보았을 때를 생각해보니 가독성이 좋지 않았습니다. (ex) 초기 데이터로 인해 예약 목록을 조회했을 때 예약 데이터가 3개 반환 된다는 확신) 
    
    따라서 테스트시에 `repository.save()`, `entityManager.persist()`, `.flush()` 등을 사용해서 조회할 데이터를 넣어주는 방식을 사용하게 되었습니다.
    
    - API 통합 테스트에 사용할 데이터 입력
        
        통합 테스트는 데이터베이스에 영향을 받아야 한다는 생각이 들어서 초기 데이터(data.sql)에 의존한 결과 `WaitingControllerTest` 는 어떤 입력이 검증에서 실패하는지 잘 나타내지 못했습니다.
        
        이에 필요한 데이터를 넣어주기 위해 API를 호출하는 방식을 사용하게 되었는데, 이는 테스트 코드도 매우 길어지게 되었고 많은 시간을 요구하게 되었습니다. 테스트가 초기 데이터(data.sql)에 어느정도 의존하는게 좋을까요?
        
3. API 요청 Optional 필드 구현에 대한 고민
    
    비즈니스 로직에서 Optional.ofNullable() 을 통해 처리하게 되었는데 서비스 단의 dto 를 만드는게 좋을까요? `ReservationService::save`
    
    추가로 이름에 따라서 사용자의 기능과 어드민의 기능으로 분리해볼 수도 있을 것 같은데 거의 비슷한 동작이라 중복되는 로직이 많이 생기기도 했고 다른 엔드포인트를 사용해야 한다는 점으로 인해 분리하지 않게 되었습니다. 요구사항에 따라서 달라지는 부분이겠죠?