### PR TITLE
[Spring Data JPA] 임지현 5, 6단계 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -28,6 +28,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(adminAuthInterceptor)
-                .addPathPatterns("/admin");
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/roomescape/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/exception/ExceptionMessage.java
@@ -13,12 +13,12 @@ public enum ExceptionMessage {
     INVALID_SECRET_KEY("요청하신 키 값이 안전하지 않습니다. 길이가 긴 키 값을 제공해 주세요."),
     WAITING_ALREADY_EXISTS("이미 예약 대기 상태입니다."),
     RESERVATION_ALREADY_EXISTS("이미 존재하는 예약입니다."),
+    RESERVATION_NOT_FOUND("해당 예약이 존재하지 않아 대기 없이 예약 가능합니다."),
 
     AUTHENTICATION_NEEDED("로그인이 필요합니다."),
     EXPIRED_TOKEN("만료된 토큰입니다."),
 
-    UNAUTHORIZED_MEMBER("접근 권한이 없는 사용자입니다."),
-    ;
+    UNAUTHORIZED_MEMBER("접근 권한이 없는 사용자입니다.");
 
     private static final String ERROR_PREFIX = "[ERROR] ";
 

--- a/src/main/java/roomescape/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/exception/ExceptionMessage.java
@@ -11,6 +11,7 @@ public enum ExceptionMessage {
     MEMBER_NOT_FOUND("존재하지 않는 멤버입니다."),
     INVALID_COOKIE_VALUE("잘못된 쿠키값입니다."),
     INVALID_SECRET_KEY("요청하신 키 값이 안전하지 않습니다. 길이가 긴 키 값을 제공해 주세요."),
+    WAITING_ALREADY_EXISTS("이미 예약 대기 상태입니다."),
 
     AUTHENTICATION_NEEDED("로그인이 필요합니다."),
     EXPIRED_TOKEN("만료된 토큰입니다."),

--- a/src/main/java/roomescape/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/exception/ExceptionMessage.java
@@ -12,11 +12,13 @@ public enum ExceptionMessage {
     INVALID_COOKIE_VALUE("잘못된 쿠키값입니다."),
     INVALID_SECRET_KEY("요청하신 키 값이 안전하지 않습니다. 길이가 긴 키 값을 제공해 주세요."),
     WAITING_ALREADY_EXISTS("이미 예약 대기 상태입니다."),
+    RESERVATION_ALREADY_EXISTS("이미 존재하는 예약입니다."),
 
     AUTHENTICATION_NEEDED("로그인이 필요합니다."),
     EXPIRED_TOKEN("만료된 토큰입니다."),
 
-    UNAUTHORIZED_MEMBER("접근 권한이 없는 사용자입니다.");
+    UNAUTHORIZED_MEMBER("접근 권한이 없는 사용자입니다."),
+    ;
 
     private static final String ERROR_PREFIX = "[ERROR] ";
 

--- a/src/main/java/roomescape/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/ReservationController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.auth.dto.LoginMember;
 import roomescape.reservation.dto.request.ReservationRequest;
+import roomescape.reservation.dto.response.MyReservationResponse;
 import roomescape.reservation.dto.response.ReservationResponse;
 import roomescape.reservation.service.ReservationService;
 
@@ -37,6 +38,12 @@ public class ReservationController {
         ReservationResponse reservation = reservationService.save(reservationRequest, loginMember);
         return ResponseEntity.created(URI.create(LOCATION_DEFAULT_VALUE + reservation.getId()))
                 .body(reservation);
+    }
+
+    @GetMapping("/reservations-mine")
+    public ResponseEntity<List<MyReservationResponse>> findMyReservations(LoginMember loginMember) {
+        List<MyReservationResponse> reservations = reservationService.findMyReservations(loginMember);
+        return ResponseEntity.ok(reservations);
     }
 
     @DeleteMapping("/reservations/{id}")

--- a/src/main/java/roomescape/reservation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/controller/ReservationController.java
@@ -48,7 +48,7 @@ public class ReservationController {
 
     @DeleteMapping("/reservations/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
-        reservationService.deleteById(id);
+        reservationService.delete(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -86,6 +86,6 @@ public class Reservation {
     }
 
     public String getRankStatus() {
-        return Status.CONFIRMED.getStatus();
+        return Status.CONFIRMED.getDescription();
     }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import roomescape.auth.dto.LoginMember;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.Time;
 import roomescape.waiting.domain.Status;
@@ -42,15 +43,28 @@ public class Reservation {
     protected Reservation() {
     }
 
-    public Reservation(long memberId, String name, LocalDate date, Time time, Theme theme) {
-        this.memberId = memberId;
+    public Reservation(LoginMember loginMember, String name, LocalDate date, Time time, Theme theme) {
+        this(date, time, theme);
+        if (isInvalidName(name)) {
+            this.memberId = loginMember.id();
+            this.name = loginMember.name();
+            return;
+        }
         this.name = name;
+    }
+
+    public Reservation(LocalDate date, Time time, Theme theme) {
         this.date = date;
         this.time = time;
         this.theme = theme;
     }
 
-    public Reservation(String name, LocalDate date, Time time, Theme theme) {
+    private boolean isInvalidName(final String name) {
+        return name == null || name.isBlank();
+    }
+
+    public Reservation(long memberId, String name, LocalDate date, Time time, Theme theme) {
+        this.memberId = memberId;
         this.name = name;
         this.date = date;
         this.time = time;

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -17,10 +17,12 @@ import java.time.LocalTime;
 @Entity
 public class Reservation {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column
+    private Long memberId;
 
     @Column(nullable = false)
     private String name;
@@ -37,6 +39,14 @@ public class Reservation {
     private Theme theme;
 
     protected Reservation() {
+    }
+
+    public Reservation(long memberId, String name, LocalDate date, Time time, Theme theme) {
+        this.memberId = memberId;
+        this.name = name;
+        this.date = date;
+        this.time = time;
+        this.theme = theme;
     }
 
     public Reservation(String name, LocalDate date, Time time, Theme theme) {

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.Time;
+import roomescape.waiting.domain.Status;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -82,5 +83,9 @@ public class Reservation {
 
     public LocalTime getTimeValue() {
         return time.getValue();
+    }
+
+    public String getRankStatus() {
+        return Status.CONFIRMED.getStatus();
     }
 }

--- a/src/main/java/roomescape/reservation/dto/request/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/dto/request/ReservationRequest.java
@@ -44,16 +44,8 @@ public class ReservationRequest {
         }
     }
 
-    public boolean isInvalidName() {
-        return this.name == null || this.name.isBlank();
-    }
-
-    public Reservation toReservationByAdmin(Time time, Theme theme) {
-        return new Reservation(name, date, time, theme);
-    }
-
-    public Reservation toReservationByMember(LoginMember loginMember, Time time, Theme theme) {
-        return new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
+    public Reservation toReservation(LoginMember loginMember, Time time, Theme theme) {
+        return new Reservation(loginMember, name, date, time, theme);
     }
 
     public String getName() {

--- a/src/main/java/roomescape/reservation/dto/request/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/dto/request/ReservationRequest.java
@@ -1,5 +1,6 @@
 package roomescape.reservation.dto.request;
 
+import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
 import roomescape.reservation.domain.Reservation;
@@ -43,12 +44,16 @@ public class ReservationRequest {
         }
     }
 
-    public ReservationRequest createWith(String name) {
-        return new ReservationRequest(name, this.date, this.theme, this.time);
-    }
-
     public boolean isInvalidName() {
         return this.name == null || this.name.isBlank();
+    }
+
+    public Reservation toReservationByAdmin(Time time, Theme theme) {
+        return new Reservation(name, date, time, theme);
+    }
+
+    public Reservation toReservationByMember(LoginMember loginMember, Time time, Theme theme) {
+        return new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
     }
 
     public String getName() {
@@ -65,9 +70,5 @@ public class ReservationRequest {
 
     public Long getTime() {
         return time;
-    }
-
-    public Reservation toReservation(Time time, Theme theme) {
-        return new Reservation(name, date, time, theme);
     }
 }

--- a/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
@@ -1,6 +1,7 @@
 package roomescape.reservation.dto.response;
 
 import roomescape.reservation.domain.Reservation;
+import roomescape.waiting.domain.WaitingWithRank;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -17,7 +18,16 @@ public record MyReservationResponse(
                 reservation.getThemeName(),
                 reservation.getDate(),
                 reservation.getTimeValue(),
-                "예약"
+                reservation.getRankStatus()
+        );
+    }
+
+    public MyReservationResponse(WaitingWithRank waitingWithRank) {
+        this(waitingWithRank.getWaitingId(),
+                waitingWithRank.getThemeName(),
+                waitingWithRank.getDate(),
+                waitingWithRank.getTimeValue(),
+                waitingWithRank.getRankStatus()
         );
     }
 }

--- a/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record MyReservationResponse(
-        long reservationId,
+        long id,
         String theme,
         LocalDate date,
         LocalTime time,

--- a/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
+++ b/src/main/java/roomescape/reservation/dto/response/MyReservationResponse.java
@@ -1,0 +1,23 @@
+package roomescape.reservation.dto.response;
+
+import roomescape.reservation.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record MyReservationResponse(
+        long reservationId,
+        String theme,
+        LocalDate date,
+        LocalTime time,
+        String status
+) {
+    public MyReservationResponse(Reservation reservation) {
+        this(reservation.getId(),
+                reservation.getThemeName(),
+                reservation.getDate(),
+                reservation.getTimeValue(),
+                "예약"
+        );
+    }
+}

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -17,4 +17,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByMemberId(Long id);
 
     boolean existsByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
+
+    boolean existsByMemberIdAndDateAndTimeAndTheme(Long memberId, LocalDate date, Time time, Theme theme);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -2,7 +2,9 @@ package roomescape.reservation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import roomescape.auth.dto.LoginMember;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.dto.response.MyReservationResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,4 +13,6 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     List<Reservation> findByDateAndThemeId(LocalDate date, long themeId);
+
+    List<Reservation> findByMemberId(Long id);
 }

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -2,9 +2,7 @@ package roomescape.reservation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import roomescape.auth.dto.LoginMember;
 import roomescape.reservation.domain.Reservation;
-import roomescape.reservation.dto.response.MyReservationResponse;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -14,7 +14,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByDateAndThemeId(LocalDate date, long themeId);
 
-    List<Reservation> findByMemberId(Long id);
+    List<Reservation> findAllByMemberId(Long id);
 
     boolean existsByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
 

--- a/src/main/java/roomescape/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/repository/ReservationRepository.java
@@ -3,6 +3,8 @@ package roomescape.reservation.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import roomescape.reservation.domain.Reservation;
+import roomescape.theme.domain.Theme;
+import roomescape.time.domain.Time;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,4 +15,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByDateAndThemeId(LocalDate date, long themeId);
 
     List<Reservation> findByMemberId(Long id);
+
+    boolean existsByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
 }

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -6,6 +6,7 @@ import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.dto.request.ReservationRequest;
+import roomescape.reservation.dto.response.MyReservationResponse;
 import roomescape.reservation.dto.response.ReservationResponse;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.theme.domain.Theme;
@@ -58,6 +59,13 @@ public class ReservationService {
     private Theme findTheme(long themeId) {
         return themeRepository.findById(themeId)
                 .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage()));
+    }
+
+    public List<MyReservationResponse> findMyReservations(LoginMember loginMember) {
+        List<Reservation> reservations = reservationRepository.findByMemberId(loginMember.id());
+        return reservations.stream()
+                .map(MyReservationResponse::new)
+                .toList();
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -16,6 +16,7 @@ import roomescape.time.domain.Time;
 import roomescape.time.repository.TimeRepository;
 import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.domain.WaitingWithRank;
+import roomescape.waiting.domain.Waitings;
 import roomescape.waiting.repository.WaitingRepository;
 
 import java.util.List;
@@ -87,8 +88,8 @@ public class ReservationService {
     }
 
     private WaitingWithRank toWaitingWithRank(Waiting waiting) {
-        List<Waiting> waitingsOnCondition = waitingRepository.findAllByDateAndTimeAndTheme(waiting.getDate(), waiting.getTime(), waiting.getTheme());
-        return new WaitingWithRank(waiting, waiting.calculateRank(waitingsOnCondition));
+        Waitings waitings = new Waitings(waitingRepository.findAllByDateAndTimeAndTheme(waiting.getDate(), waiting.getTime(), waiting.getTheme()));
+        return new WaitingWithRank(waiting, waitings.calculateRank(waiting));
     }
 
     @Transactional

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -13,8 +13,11 @@ import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
 import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.domain.WaitingWithRank;
+import roomescape.waiting.repository.WaitingRepository;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 public class ReservationService {
@@ -22,11 +25,13 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final TimeRepository timeRepository;
     private final ThemeRepository themeRepository;
+    private final WaitingRepository waitingRepository;
 
-    public ReservationService(ReservationRepository reservationRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+    public ReservationService(ReservationRepository reservationRepository, TimeRepository timeRepository, ThemeRepository themeRepository, WaitingRepository waitingRepository) {
         this.reservationRepository = reservationRepository;
         this.timeRepository = timeRepository;
         this.themeRepository = themeRepository;
+        this.waitingRepository = waitingRepository;
     }
 
     public List<ReservationResponse> findAll() {
@@ -63,8 +68,11 @@ public class ReservationService {
 
     public List<MyReservationResponse> findMyReservations(LoginMember loginMember) {
         List<Reservation> reservations = reservationRepository.findByMemberId(loginMember.id());
-        return reservations.stream()
-                .map(MyReservationResponse::new)
+        List<WaitingWithRank> waitings = waitingRepository.findWaitingsWithRankByMemberId(loginMember.id());
+
+        return Stream.concat(
+                reservations.stream().map(MyReservationResponse::new),
+                waitings.stream().map(MyReservationResponse::new))
                 .toList();
     }
 

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -42,6 +42,7 @@ public class ReservationService {
 
     public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
         Reservation reservation = createReservation(reservationRequest, loginMember);
+        validateDuplicateReservation(reservation);
         Reservation reservationWithId = reservationRepository.save(reservation);
         return new ReservationResponse(reservationWithId);
     }
@@ -66,13 +67,19 @@ public class ReservationService {
                 .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage()));
     }
 
+    private void validateDuplicateReservation(Reservation reservation) {
+        if (reservationRepository.existsByDateAndTimeAndTheme(reservation.getDate(), reservation.getTime(), reservation.getTheme())) {
+            throw new BadRequestException(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+        }
+    }
+
     public List<MyReservationResponse> findMyReservations(LoginMember loginMember) {
         List<Reservation> reservations = reservationRepository.findByMemberId(loginMember.id());
         List<WaitingWithRank> waitings = waitingRepository.findWaitingsWithRankByMemberId(loginMember.id());
 
         return Stream.concat(
-                reservations.stream().map(MyReservationResponse::new),
-                waitings.stream().map(MyReservationResponse::new))
+                        reservations.stream().map(MyReservationResponse::new),
+                        waitings.stream().map(MyReservationResponse::new))
                 .toList();
     }
 

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -1,6 +1,7 @@
 package roomescape.reservation.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 @Service
+@Transactional(readOnly = true)
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
@@ -41,6 +43,7 @@ public class ReservationService {
                 .toList();
     }
 
+    @Transactional
     public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
         Reservation reservation = createReservation(reservationRequest, loginMember);
         validateDuplicateReservation(reservation);
@@ -88,6 +91,7 @@ public class ReservationService {
         return new WaitingWithRank(waiting, waiting.calculateRank(waitingsOnCondition));
     }
 
+    @Transactional
     public void delete(Long id) {
         reservationRepository.findById(id)
                 .ifPresent(reservation -> {

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -83,7 +83,19 @@ public class ReservationService {
                 .toList();
     }
 
-    public void deleteById(Long id) {
-        reservationRepository.deleteById(id);
+    public void delete(Long id) {
+        reservationRepository.findById(id)
+                .ifPresent(reservation -> {
+                    reservationRepository.deleteById(id);
+                    saveFirstWaitingAsReservation(reservation);
+                });
+    }
+
+    private void saveFirstWaitingAsReservation(Reservation reservation) {
+        waitingRepository.findFirstWaitingByDateAndTimeAndTheme(reservation.getDate(), reservation.getTime(), reservation.getTheme())
+                .ifPresent(waiting -> {
+                    reservationRepository.save(waiting.toReservation());
+                    waitingRepository.delete(waiting);
+                });
     }
 }

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -28,25 +28,26 @@ public class ReservationService {
         this.themeRepository = themeRepository;
     }
 
+    public List<ReservationResponse> findAll() {
+        return reservationRepository.findAll().stream()
+                .map(ReservationResponse::new)
+                .toList();
+    }
+
     public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
-        reservationRequest = updateRequestIfNameIsInvalid(reservationRequest, loginMember);
-        Time time = findTime(reservationRequest.getTime());
-        Theme theme = findTheme(reservationRequest.getTheme());
-        Reservation reservation = reservationRequest.toReservation(time, theme);
+        Reservation reservation = createReservation(reservationRequest, loginMember);
         Reservation reservationWithId = reservationRepository.save(reservation);
         return new ReservationResponse(reservationWithId);
     }
 
-    private ReservationRequest updateRequestIfNameIsInvalid(ReservationRequest reservationRequest, LoginMember loginMember) {
-        if (reservationRequest.isInvalidName()) {
-            reservationRequest = createReservationRequestWithName(reservationRequest, loginMember);
-        }
-        return reservationRequest;
-    }
+    private Reservation createReservation(ReservationRequest reservationRequest, LoginMember loginMember) {
+        Time time = findTime(reservationRequest.getTime());
+        Theme theme = findTheme(reservationRequest.getTheme());
 
-    private ReservationRequest createReservationRequestWithName(ReservationRequest reservationRequest, LoginMember loginMember) {
-        String name = loginMember.name();
-        return reservationRequest.createWith(name);
+        if (reservationRequest.isInvalidName()) {
+            return reservationRequest.toReservationByMember(loginMember, time, theme);
+        }
+        return reservationRequest.toReservationByAdmin(time, theme);
     }
 
     private Time findTime(long timeId) {
@@ -61,11 +62,5 @@ public class ReservationService {
 
     public void deleteById(Long id) {
         reservationRepository.deleteById(id);
-    }
-
-    public List<ReservationResponse> findAll() {
-        return reservationRepository.findAll().stream()
-                .map(ReservationResponse::new)
-                .toList();
     }
 }

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -50,11 +50,7 @@ public class ReservationService {
     private Reservation createReservation(ReservationRequest reservationRequest, LoginMember loginMember) {
         Time time = findTime(reservationRequest.getTime());
         Theme theme = findTheme(reservationRequest.getTheme());
-
-        if (reservationRequest.isInvalidName()) {
-            return reservationRequest.toReservationByMember(loginMember, time, theme);
-        }
-        return reservationRequest.toReservationByAdmin(time, theme);
+        return reservationRequest.toReservation(loginMember, time, theme);
     }
 
     private Time findTime(long timeId) {

--- a/src/main/java/roomescape/reservation/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/service/ReservationService.java
@@ -13,6 +13,7 @@ import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
 import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.domain.WaitingWithRank;
 import roomescape.waiting.repository.WaitingRepository;
 
@@ -70,13 +71,21 @@ public class ReservationService {
     }
 
     public List<MyReservationResponse> findMyReservations(LoginMember loginMember) {
-        List<Reservation> reservations = reservationRepository.findByMemberId(loginMember.id());
-        List<WaitingWithRank> waitings = waitingRepository.findWaitingsWithRankByMemberId(loginMember.id());
+        List<Reservation> reservations = reservationRepository.findAllByMemberId(loginMember.id());
+        List<Waiting> waitings = waitingRepository.findAllByMemberId(loginMember.id());
+        List<WaitingWithRank> waitingWithRanks = waitings.stream()
+                .map(this::toWaitingWithRank)
+                .toList();
 
         return Stream.concat(
                         reservations.stream().map(MyReservationResponse::new),
-                        waitings.stream().map(MyReservationResponse::new))
+                        waitingWithRanks.stream().map(MyReservationResponse::new))
                 .toList();
+    }
+
+    private WaitingWithRank toWaitingWithRank(Waiting waiting) {
+        List<Waiting> waitingsOnCondition = waitingRepository.findAllByDateAndTimeAndTheme(waiting.getDate(), waiting.getTime(), waiting.getTheme());
+        return new WaitingWithRank(waiting, waiting.calculateRank(waitingsOnCondition));
     }
 
     public void delete(Long id) {

--- a/src/main/java/roomescape/waiting/controller/WaitingController.java
+++ b/src/main/java/roomescape/waiting/controller/WaitingController.java
@@ -2,6 +2,8 @@ package roomescape.waiting.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import roomescape.auth.dto.LoginMember;
@@ -27,5 +29,11 @@ public class WaitingController {
         WaitingResponse waiting = waitingService.createWaiting(waitingRequest, loginMember);
         return ResponseEntity.created(URI.create(LOCATION_DEFAULT_VALUE + waiting.id()))
                 .body(waiting);
+    }
+
+    @DeleteMapping("/waitings/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        waitingService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/waiting/controller/WaitingController.java
+++ b/src/main/java/roomescape/waiting/controller/WaitingController.java
@@ -1,0 +1,31 @@
+package roomescape.waiting.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import roomescape.auth.dto.LoginMember;
+import roomescape.waiting.dto.request.WaitingRequest;
+import roomescape.waiting.dto.response.WaitingResponse;
+import roomescape.waiting.service.WaitingService;
+
+import java.net.URI;
+
+@Controller
+public class WaitingController {
+
+    private static final String LOCATION_DEFAULT_VALUE = "/waitings/";
+
+    private final WaitingService waitingService;
+
+    public WaitingController(WaitingService waitingService) {
+        this.waitingService = waitingService;
+    }
+
+    @PostMapping("/waitings")
+    public ResponseEntity<WaitingResponse> createWaiting(@RequestBody WaitingRequest waitingRequest, LoginMember loginMember) {
+        WaitingResponse waiting = waitingService.createWaiting(waitingRequest, loginMember);
+        return ResponseEntity.created(URI.create(LOCATION_DEFAULT_VALUE + waiting.id()))
+                .body(waiting);
+    }
+}

--- a/src/main/java/roomescape/waiting/domain/Status.java
+++ b/src/main/java/roomescape/waiting/domain/Status.java
@@ -11,7 +11,7 @@ public enum Status {
         this.description = description;
     }
 
-    public String getStatus(long rank) {
+    public String getDescriptionWith(long rank) {
         if (this == WAITING) {
             return rank + description;
         }

--- a/src/main/java/roomescape/waiting/domain/Status.java
+++ b/src/main/java/roomescape/waiting/domain/Status.java
@@ -5,20 +5,20 @@ public enum Status {
     CONFIRMED("예약"),
     WAITING("번째 예약대기");
 
-    private String status;
+    private final String description;
 
-    Status(String status) {
-        this.status = status;
+    Status(String description) {
+        this.description = description;
     }
 
     public String getStatus(long rank) {
         if (this == WAITING) {
-            return rank + status;
+            return rank + description;
         }
-        return status;
+        return description;
     }
 
-    public String getStatus() {
-        return status;
+    public String getDescription() {
+        return description;
     }
 }

--- a/src/main/java/roomescape/waiting/domain/Status.java
+++ b/src/main/java/roomescape/waiting/domain/Status.java
@@ -1,0 +1,24 @@
+package roomescape.waiting.domain;
+
+public enum Status {
+
+    CONFIRMED("예약"),
+    WAITING("번째 예약대기");
+
+    private String status;
+
+    Status(String status) {
+        this.status = status;
+    }
+
+    public String getStatus(long rank) {
+        if (this == WAITING) {
+            return rank + status;
+        }
+        return status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -57,6 +57,14 @@ public class Waiting {
         return date;
     }
 
+    public Time getTime() {
+        return time;
+    }
+
+    public Theme getTheme() {
+        return theme;
+    }
+
     public LocalTime getTimeValue() {
         return time.getValue();
     }

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -1,0 +1,67 @@
+package roomescape.waiting.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import roomescape.theme.domain.Theme;
+import roomescape.time.domain.Time;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+public class Waiting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "time_id", nullable = false)
+    private Time time;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "theme_id", nullable = false)
+    private Theme theme;
+
+    protected Waiting() {
+    }
+
+    public Waiting(long memberId, LocalDate date, Time time, Theme theme) {
+        this.memberId = memberId;
+        this.date = date;
+        this.time = time;
+        this.theme = theme;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTimeValue() {
+        return time.getValue();
+    }
+
+    public String getThemeName() {
+        return theme.getName();
+    }
+}

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -14,9 +14,12 @@ import roomescape.time.domain.Time;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Entity
 public class Waiting {
+
+    private static final int BASE_RANK = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,6 +55,16 @@ public class Waiting {
 
     public Reservation toReservation() {
         return new Reservation(memberId, name, date, time, theme);
+    }
+
+    public long calculateRank(List<Waiting> waitings) {
+        return waitings.stream()
+                .filter(this::isLaterThan)
+                .count() + BASE_RANK;
+    }
+
+    private boolean isLaterThan(Waiting waiting) {
+        return waiting.getId() < this.id;
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -14,12 +14,9 @@ import roomescape.time.domain.Time;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 
 @Entity
-public class Waiting {
-
-    private static final int BASE_RANK = 1;
+public class Waiting implements Comparable<Waiting> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,14 +54,13 @@ public class Waiting {
         return new Reservation(memberId, name, date, time, theme);
     }
 
-    public long calculateRank(List<Waiting> waitings) {
-        return waitings.stream()
-                .filter(this::isLaterThan)
-                .count() + BASE_RANK;
+    public boolean isBefore(Waiting target) {
+        return this.compareTo(target) < 0;
     }
 
-    private boolean isLaterThan(Waiting waiting) {
-        return waiting.getId() < this.id;
+    @Override
+    public int compareTo(Waiting other) {
+        return Long.compare(this.id, other.id);
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/waiting/domain/Waiting.java
+++ b/src/main/java/roomescape/waiting/domain/Waiting.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import roomescape.reservation.domain.Reservation;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.Time;
 
@@ -25,6 +26,9 @@ public class Waiting {
     private Long memberId;
 
     @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
     private LocalDate date;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -38,11 +42,16 @@ public class Waiting {
     protected Waiting() {
     }
 
-    public Waiting(long memberId, LocalDate date, Time time, Theme theme) {
+    public Waiting(long memberId, String name, LocalDate date, Time time, Theme theme) {
         this.memberId = memberId;
+        this.name = name;
         this.date = date;
         this.time = time;
         this.theme = theme;
+    }
+
+    public Reservation toReservation() {
+        return new Reservation(memberId, name, date, time, theme);
     }
 
     public Long getId() {
@@ -51,6 +60,10 @@ public class Waiting {
 
     public Long getMemberId() {
         return memberId;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public LocalDate getDate() {

--- a/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
@@ -1,0 +1,35 @@
+package roomescape.waiting.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class WaitingWithRank {
+
+    private final Waiting waiting;
+    private final Long rank;
+
+    public WaitingWithRank(Waiting waiting, Long rank) {
+        this.waiting = waiting;
+        this.rank = rank;
+    }
+
+    public Long getWaitingId() {
+        return waiting.getId();
+    }
+
+    public LocalDate getDate() {
+        return waiting.getDate();
+    }
+
+    public LocalTime getTimeValue() {
+        return waiting.getTimeValue();
+    }
+
+    public String getThemeName() {
+        return waiting.getThemeName();
+    }
+
+    public String getRankStatus() {
+        return Status.WAITING.getStatus(rank);
+    }
+}

--- a/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
@@ -17,6 +17,10 @@ public class WaitingWithRank {
         return waiting.getId();
     }
 
+    public Long getMemberId() {
+        return waiting.getMemberId();
+    }
+
     public LocalDate getDate() {
         return waiting.getDate();
     }

--- a/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
@@ -17,10 +17,6 @@ public class WaitingWithRank {
         return waiting.getId();
     }
 
-    public Long getMemberId() {
-        return waiting.getMemberId();
-    }
-
     public LocalDate getDate() {
         return waiting.getDate();
     }

--- a/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
+++ b/src/main/java/roomescape/waiting/domain/WaitingWithRank.java
@@ -34,6 +34,6 @@ public class WaitingWithRank {
     }
 
     public String getRankStatus() {
-        return Status.WAITING.getStatus(rank);
+        return Status.WAITING.getDescriptionWith(rank);
     }
 }

--- a/src/main/java/roomescape/waiting/domain/Waitings.java
+++ b/src/main/java/roomescape/waiting/domain/Waitings.java
@@ -1,0 +1,20 @@
+package roomescape.waiting.domain;
+
+import java.util.List;
+
+public class Waitings {
+
+    private static final int BASE_RANK = 1;
+
+    private final List<Waiting> waitings;
+
+    public Waitings(final List<Waiting> waitings) {
+        this.waitings = waitings;
+    }
+
+    public long calculateRank(Waiting target) {
+        return waitings.stream()
+                .filter(waiting -> waiting.isBefore(target))
+                .count() + BASE_RANK;
+    }
+}

--- a/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
@@ -1,5 +1,7 @@
 package roomescape.waiting.dto.request;
 
+import roomescape.exception.BadRequestException;
+import roomescape.exception.ExceptionMessage;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.Time;
 import roomescape.waiting.domain.Waiting;
@@ -11,6 +13,30 @@ public record WaitingRequest(
         long time,
         long theme
 ) {
+    public WaitingRequest {
+        validateDate(date);
+        validateTheme(theme);
+        validateTime(time);
+    }
+
+    private void validateDate(final LocalDate date) {
+        if (date == null) {
+            throw new BadRequestException(ExceptionMessage.INVALID_DATE.getMessage());
+        }
+    }
+
+    private void validateTheme(final Long themeId) {
+        if (themeId == null) {
+            throw new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage());
+        }
+    }
+
+    private void validateTime(final Long timeId) {
+        if (timeId == null) {
+            throw new BadRequestException(ExceptionMessage.INVALID_TIME.getMessage());
+        }
+    }
+
     public Waiting toWaiting(long memberId, String name, Time time, Theme theme) {
         return new Waiting(
                 memberId,

--- a/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
@@ -1,0 +1,22 @@
+package roomescape.waiting.dto.request;
+
+import roomescape.theme.domain.Theme;
+import roomescape.time.domain.Time;
+import roomescape.waiting.domain.Waiting;
+
+import java.time.LocalDate;
+
+public record WaitingRequest(
+        LocalDate date,
+        long time,
+        long theme
+) {
+    public Waiting toWaiting(long memberId, Time time, Theme theme) {
+        return new Waiting(
+                memberId,
+                date,
+                time,
+                theme
+        );
+    }
+}

--- a/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
@@ -11,9 +11,10 @@ public record WaitingRequest(
         long time,
         long theme
 ) {
-    public Waiting toWaiting(long memberId, Time time, Theme theme) {
+    public Waiting toWaiting(long memberId, String name, Time time, Theme theme) {
         return new Waiting(
                 memberId,
+                name,
                 date,
                 time,
                 theme

--- a/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/roomescape/waiting/dto/request/WaitingRequest.java
@@ -38,12 +38,6 @@ public record WaitingRequest(
     }
 
     public Waiting toWaiting(long memberId, String name, Time time, Theme theme) {
-        return new Waiting(
-                memberId,
-                name,
-                date,
-                time,
-                theme
-        );
+        return new Waiting(memberId, name, date, time, theme);
     }
 }

--- a/src/main/java/roomescape/waiting/dto/response/WaitingResponse.java
+++ b/src/main/java/roomescape/waiting/dto/response/WaitingResponse.java
@@ -1,0 +1,24 @@
+package roomescape.waiting.dto.response;
+
+import roomescape.waiting.domain.Waiting;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WaitingResponse(
+        long id,
+        long memberId,
+        LocalDate date,
+        LocalTime time,
+        String theme
+) {
+    public WaitingResponse(Waiting waiting) {
+        this(
+                waiting.getId(),
+                waiting.getMemberId(),
+                waiting.getDate(),
+                waiting.getTimeValue(),
+                waiting.getThemeName()
+        );
+    }
+}

--- a/src/main/java/roomescape/waiting/dto/response/WaitingResponse.java
+++ b/src/main/java/roomescape/waiting/dto/response/WaitingResponse.java
@@ -1,24 +1,7 @@
 package roomescape.waiting.dto.response;
 
-import roomescape.waiting.domain.Waiting;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-
 public record WaitingResponse(
         long id,
-        long memberId,
-        LocalDate date,
-        LocalTime time,
-        String theme
+        long waitingNumber
 ) {
-    public WaitingResponse(Waiting waiting) {
-        this(
-                waiting.getId(),
-                waiting.getMemberId(),
-                waiting.getDate(),
-                waiting.getTimeValue(),
-                waiting.getThemeName()
-        );
-    }
 }

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -3,13 +3,18 @@ package roomescape.waiting.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import roomescape.theme.domain.Theme;
+import roomescape.time.domain.Time;
 import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.domain.WaitingWithRank;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
+    boolean existsByMemberIdAndDateAndTimeAndTheme(Long memberId, LocalDate date, Time time, Theme theme);
 
     @Query("SELECT new roomescape.waiting.domain.WaitingWithRank(" +
             "    w, " +

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -16,6 +16,16 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     boolean existsByMemberIdAndDateAndTimeAndTheme(Long memberId, LocalDate date, Time time, Theme theme);
 
+    @Query("SELECT CAST((SELECT COUNT(w2) + 1 " +
+            "          FROM Waiting w2 " +
+            "          WHERE w2.theme = w.theme " +
+            "            AND w2.date = w.date " +
+            "            AND w2.time = w.time " +
+            "            AND w2.id < w.id) AS long) " +
+            "FROM Waiting w " +
+            "WHERE w.memberId = :memberId")
+    Long findWaitingNumberByMemberId(Long memberId);
+
     @Query("SELECT new roomescape.waiting.domain.WaitingWithRank(" +
             "    w, " +
             "    CAST((SELECT COUNT(w2) + 1 " +

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -10,6 +10,7 @@ import roomescape.waiting.domain.WaitingWithRank;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
@@ -37,4 +38,12 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             "FROM Waiting w " +
             "WHERE w.memberId = :memberId")
     List<WaitingWithRank> findWaitingsWithRankByMemberId(Long memberId);
+
+    @Query("SELECT w " +
+            "FROM Waiting w " +
+            "WHERE w.date = :date " +
+            "  AND w.time = :time " +
+            "  AND w.theme = :theme " +
+            "ORDER BY w.id ASC")
+    Optional<Waiting> findFirstWaitingByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
 }

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Repository;
 import roomescape.theme.domain.Theme;
 import roomescape.time.domain.Time;
 import roomescape.waiting.domain.Waiting;
-import roomescape.waiting.domain.WaitingWithRank;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -27,17 +26,9 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             "WHERE w.memberId = :memberId")
     Long findWaitingNumberByMemberId(Long memberId);
 
-    @Query("SELECT new roomescape.waiting.domain.WaitingWithRank(" +
-            "    w, " +
-            "    CAST((SELECT COUNT(w2) + 1 " +
-            "          FROM Waiting w2 " +
-            "          WHERE w2.theme = w.theme " +
-            "            AND w2.date = w.date " +
-            "            AND w2.time = w.time " +
-            "            AND w2.id < w.id) AS long)) " +
-            "FROM Waiting w " +
-            "WHERE w.memberId = :memberId")
-    List<WaitingWithRank> findWaitingsWithRankByMemberId(Long memberId);
+    List<Waiting> findAllByMemberId(Long memberId);
+
+    List<Waiting> findAllByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
 
     @Query("SELECT w " +
             "FROM Waiting w " +

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -1,0 +1,25 @@
+package roomescape.waiting.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import roomescape.waiting.domain.Waiting;
+import roomescape.waiting.domain.WaitingWithRank;
+
+import java.util.List;
+
+@Repository
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
+    @Query("SELECT new roomescape.waiting.domain.WaitingWithRank(" +
+            "    w, " +
+            "    CAST((SELECT COUNT(w2) + 1 " +
+            "          FROM Waiting w2 " +
+            "          WHERE w2.theme = w.theme " +
+            "            AND w2.date = w.date " +
+            "            AND w2.time = w.time " +
+            "            AND w2.id < w.id) AS long)) " +
+            "FROM Waiting w " +
+            "WHERE w.memberId = :memberId")
+    List<WaitingWithRank> findWaitingsWithRankByMemberId(Long memberId);
+}

--- a/src/main/java/roomescape/waiting/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/waiting/repository/WaitingRepository.java
@@ -44,6 +44,8 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             "WHERE w.date = :date " +
             "  AND w.time = :time " +
             "  AND w.theme = :theme " +
-            "ORDER BY w.id ASC")
+            "ORDER BY w.id ASC " +
+            "LIMIT 1"
+    )
     Optional<Waiting> findFirstWaitingByDateAndTimeAndTheme(LocalDate date, Time time, Theme theme);
 }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -33,7 +33,9 @@ public class WaitingService {
 
         validateDuplicateWaiting(waiting);
         Waiting savedWaiting = waitingRepository.save(waiting);
-        return new WaitingResponse(savedWaiting);
+
+        Long waitingNumber = waitingRepository.findWaitingNumberByMemberId(loginMember.id());
+        return new WaitingResponse(savedWaiting.getId(), waitingNumber);
     }
 
     private Time findTime(long timeId) {

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
+import roomescape.reservation.repository.ReservationRepository;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
@@ -16,11 +17,13 @@ import roomescape.waiting.repository.WaitingRepository;
 @Service
 public class WaitingService {
 
+    private final ReservationRepository reservationRepository;
     private final WaitingRepository waitingRepository;
     private final TimeRepository timeRepository;
     private final ThemeRepository themeRepository;
 
-    public WaitingService(WaitingRepository waitingRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+    public WaitingService(ReservationRepository reservationRepository, WaitingRepository waitingRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+        this.reservationRepository = reservationRepository;
         this.waitingRepository = waitingRepository;
         this.timeRepository = timeRepository;
         this.themeRepository = themeRepository;
@@ -49,6 +52,9 @@ public class WaitingService {
     }
 
     private void validateDuplicateWaiting(Waiting waiting) {
+        if (reservationRepository.existsByMemberIdAndDateAndTimeAndTheme(waiting.getMemberId(), waiting.getDate(), waiting.getTime(), waiting.getTheme())) {
+            throw new BadRequestException(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+        }
         if (waitingRepository.existsByMemberIdAndDateAndTimeAndTheme(waiting.getMemberId(), waiting.getDate(), waiting.getTime(), waiting.getTheme())) {
             throw new BadRequestException(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
         }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -32,7 +32,7 @@ public class WaitingService {
     public WaitingResponse createWaiting(WaitingRequest waitingRequest, LoginMember loginMember) {
         Time time = findTime(waitingRequest.time());
         Theme theme = findTheme(waitingRequest.theme());
-        Waiting waiting = waitingRequest.toWaiting(loginMember.id(), time, theme);
+        Waiting waiting = waitingRequest.toWaiting(loginMember.id(), loginMember.name(), time, theme);
 
         validateDuplicateWaiting(waiting);
         Waiting savedWaiting = waitingRepository.save(waiting);

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -38,7 +38,7 @@ public class WaitingService {
         Waiting waiting = waitingRequest.toWaiting(loginMember.id(), loginMember.name(), time, theme);
 
         validateIsAlreadyReserved(waiting);
-        validateDuplicateWaiting(waiting);
+        validateUniqueWaiting(waiting);
         Waiting savedWaiting = waitingRepository.save(waiting);
 
         Long waitingNumber = waitingRepository.findWaitingNumberByMemberId(loginMember.id());
@@ -61,7 +61,7 @@ public class WaitingService {
         }
     }
 
-    private void validateDuplicateWaiting(Waiting waiting) {
+    private void validateUniqueWaiting(Waiting waiting) {
         if (reservationRepository.existsByMemberIdAndDateAndTimeAndTheme(waiting.getMemberId(), waiting.getDate(), waiting.getTime(), waiting.getTheme())) {
             throw new BadRequestException(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
         }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -51,4 +51,8 @@ public class WaitingService {
             throw new BadRequestException(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
         }
     }
+
+    public void delete(Long id) {
+        waitingRepository.deleteById(id);
+    }
 }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -1,6 +1,7 @@
 package roomescape.waiting.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
@@ -15,6 +16,7 @@ import roomescape.waiting.dto.response.WaitingResponse;
 import roomescape.waiting.repository.WaitingRepository;
 
 @Service
+@Transactional(readOnly = true)
 public class WaitingService {
 
     private final ReservationRepository reservationRepository;
@@ -29,6 +31,7 @@ public class WaitingService {
         this.themeRepository = themeRepository;
     }
 
+    @Transactional
     public WaitingResponse createWaiting(WaitingRequest waitingRequest, LoginMember loginMember) {
         Time time = findTime(waitingRequest.time());
         Theme theme = findTheme(waitingRequest.theme());
@@ -67,6 +70,7 @@ public class WaitingService {
         }
     }
 
+    @Transactional
     public void delete(Long id) {
         waitingRepository.deleteById(id);
     }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -30,7 +30,8 @@ public class WaitingService {
         Time time = findTime(waitingRequest.time());
         Theme theme = findTheme(waitingRequest.theme());
         Waiting waiting = waitingRequest.toWaiting(loginMember.id(), time, theme);
-        //TODO: 이미 대기 신청 하였는지 검증
+
+        validateDuplicateWaiting(waiting);
         Waiting savedWaiting = waitingRepository.save(waiting);
         return new WaitingResponse(savedWaiting);
     }
@@ -43,5 +44,10 @@ public class WaitingService {
     private Theme findTheme(long themeId) {
         return themeRepository.findById(themeId)
                 .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage()));
+    }
+
+    private void validateDuplicateWaiting(Waiting waiting) {
+        waitingRepository.findById(waiting.getId())
+                .orElseThrow(() -> new BadRequestException(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage()));
     }
 }

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -1,0 +1,47 @@
+package roomescape.waiting.service;
+
+import org.springframework.stereotype.Service;
+import roomescape.auth.dto.LoginMember;
+import roomescape.exception.BadRequestException;
+import roomescape.exception.ExceptionMessage;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.Time;
+import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.domain.Waiting;
+import roomescape.waiting.dto.request.WaitingRequest;
+import roomescape.waiting.dto.response.WaitingResponse;
+import roomescape.waiting.repository.WaitingRepository;
+
+@Service
+public class WaitingService {
+
+    private final WaitingRepository waitingRepository;
+    private final TimeRepository timeRepository;
+    private final ThemeRepository themeRepository;
+
+    public WaitingService(WaitingRepository waitingRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+        this.waitingRepository = waitingRepository;
+        this.timeRepository = timeRepository;
+        this.themeRepository = themeRepository;
+    }
+
+    public WaitingResponse createWaiting(WaitingRequest waitingRequest, LoginMember loginMember) {
+        Time time = findTime(waitingRequest.time());
+        Theme theme = findTheme(waitingRequest.theme());
+        Waiting waiting = waitingRequest.toWaiting(loginMember.id(), time, theme);
+        //TODO: 이미 대기 신청 하였는지 검증
+        Waiting savedWaiting = waitingRepository.save(waiting);
+        return new WaitingResponse(savedWaiting);
+    }
+
+    private Time findTime(long timeId) {
+        return timeRepository.findById(timeId)
+                .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_TIME.getMessage()));
+    }
+
+    private Theme findTheme(long themeId) {
+        return themeRepository.findById(themeId)
+                .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage()));
+    }
+}

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -34,6 +34,7 @@ public class WaitingService {
         Theme theme = findTheme(waitingRequest.theme());
         Waiting waiting = waitingRequest.toWaiting(loginMember.id(), loginMember.name(), time, theme);
 
+        validateIsAlreadyReserved(waiting);
         validateDuplicateWaiting(waiting);
         Waiting savedWaiting = waitingRepository.save(waiting);
 
@@ -49,6 +50,12 @@ public class WaitingService {
     private Theme findTheme(long themeId) {
         return themeRepository.findById(themeId)
                 .orElseThrow(() -> new BadRequestException(ExceptionMessage.INVALID_THEME.getMessage()));
+    }
+
+    private void validateIsAlreadyReserved(Waiting waiting) {
+        if (!reservationRepository.existsByDateAndTimeAndTheme(waiting.getDate(), waiting.getTime(), waiting.getTheme())) {
+            throw new BadRequestException(ExceptionMessage.RESERVATION_NOT_FOUND.getMessage());
+        }
     }
 
     private void validateDuplicateWaiting(Waiting waiting) {

--- a/src/main/java/roomescape/waiting/service/WaitingService.java
+++ b/src/main/java/roomescape/waiting/service/WaitingService.java
@@ -47,7 +47,8 @@ public class WaitingService {
     }
 
     private void validateDuplicateWaiting(Waiting waiting) {
-        waitingRepository.findById(waiting.getId())
-                .orElseThrow(() -> new BadRequestException(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage()));
+        if (waitingRepository.existsByMemberIdAndDateAndTimeAndTheme(waiting.getMemberId(), waiting.getDate(), waiting.getTime(), waiting.getTheme())) {
+            throw new BadRequestException(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
+        }
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS reservation
     id       BIGINT       NOT NULL AUTO_INCREMENT,
     `date`     DATE NOT NULL,
     name     VARCHAR(255) NOT NULL,
+    member_id  BIGINT,
     time_id  BIGINT,
     theme_id BIGINT,
     PRIMARY KEY (id),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -27,12 +27,12 @@ CREATE TABLE IF NOT EXISTS member
 
 CREATE TABLE IF NOT EXISTS reservation
 (
-    id       BIGINT       NOT NULL AUTO_INCREMENT,
-    `date`     DATE NOT NULL,
-    name     VARCHAR(255) NOT NULL,
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    `date`     DATE         NOT NULL,
+    name       VARCHAR(255) NOT NULL,
     member_id  BIGINT,
-    time_id  BIGINT,
-    theme_id BIGINT,
+    time_id    BIGINT,
+    theme_id   BIGINT,
     PRIMARY KEY (id),
     FOREIGN KEY (time_id) REFERENCES time (id),
     FOREIGN KEY (theme_id) REFERENCES theme (id)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -54,7 +54,10 @@ VALUES ('10:00'),
        ('18:00'),
        ('20:00');
 
+INSERT INTO reservation (member_id, name, date, time_id, theme_id)
+VALUES (1, '', '2024-03-01', 1, 1),
+       (1, '', '2024-03-01', 2, 2),
+       (1, '', '2024-03-01', 3, 3);
+
 INSERT INTO reservation (name, date, time_id, theme_id)
-VALUES ('어드민', '2024-03-01', 1, 1),
-       ('어드민', '2024-03-01', 2, 2),
-       ('어드민', '2024-03-01', 3, 3);
+VALUES ('브라운', '2024-03-01', 1, 2);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -7,9 +7,12 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.dto.response.MyReservationResponse;
 import roomescape.reservation.dto.response.ReservationResponse;
+import roomescape.waiting.dto.response.WaitingResponse;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,6 +89,60 @@ class MissionStepTest {
                 .get("/admin")
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    @Test
+    void 오단계() {
+        String adminToken = createToken("admin@email.com", "password");
+
+        List<MyReservationResponse> reservations = RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/reservations-mine")
+                .then().log().all()
+                .statusCode(200)
+                .extract().jsonPath().getList(".", MyReservationResponse.class);
+
+        assertThat(reservations).hasSize(3);
+    }
+
+    @Test
+    void 육단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        // 예약 대기 생성
+        WaitingResponse waiting = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", brownToken)
+                .contentType(ContentType.JSON)
+                .post("/waitings")
+                .then().log().all()
+                .statusCode(201)
+                .extract().as(WaitingResponse.class);
+
+        // 내 예약 목록 조회
+        List<MyReservationResponse> myReservations = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", brownToken)
+                .contentType(ContentType.JSON)
+                .get("/reservations-mine")
+                .then().log().all()
+                .statusCode(200)
+                .extract().jsonPath().getList(".", MyReservationResponse.class);
+
+        // 예약 대기 상태 확인
+        String status = myReservations.stream()
+                .filter(it -> it.reservationId() == waiting.id())
+                .filter(it -> !it.status().equals("예약"))
+                .findFirst()
+                .map(it -> it.status())
+                .orElse(null);
+
+        assertThat(status).isEqualTo("1번째 예약대기");
     }
 
     private String createToken(String email, String password) {

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -43,7 +43,7 @@ class MissionStepTest {
         String token = createToken("admin@email.com", "password");
 
         Map<String, String> params = new HashMap<>();
-        params.put("date", "2024-03-01");
+        params.put("date", "2025-03-01");
         params.put("time", "1");
         params.put("theme", "1");
 
@@ -59,6 +59,7 @@ class MissionStepTest {
         assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
 
         params.put("name", "브라운");
+        params.put("time", "2");
 
         ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
                 .body(params)

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -137,7 +137,7 @@ class MissionStepTest {
 
         // 예약 대기 상태 확인
         String status = myReservations.stream()
-                .filter(it -> it.reservationId() == waiting.id())
+                .filter(it -> it.id() == waiting.id())
                 .filter(it -> !it.status().equals("예약"))
                 .findFirst()
                 .map(it -> it.status())

--- a/src/test/java/roomescape/auth/JwtTokenManagerTest.java
+++ b/src/test/java/roomescape/auth/JwtTokenManagerTest.java
@@ -19,7 +19,10 @@ class JwtTokenManagerTest {
 
     @Test
     void 시크릿_키_길이가_충분하지_않은경우_예외가_발생한다() {
-        assertThatThrownBy(() -> new JwtTokenManager("short"))
+        // given
+        String shortSecretKey = "short";
+        // when & then
+        assertThatThrownBy(() -> new JwtTokenManager(shortSecretKey))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(ExceptionMessage.INVALID_SECRET_KEY.getMessage());
     }
@@ -61,8 +64,8 @@ class JwtTokenManagerTest {
     }
 
     private JwtTokenManager createJwtTokenManager() {
-        String testSecretKey = "test-secret-keyyyyyyyyyyyyyyyyyyyyy";
-        return new JwtTokenManager(testSecretKey);
+        String longSecretKey = "test-secret-keyyyyyyyyyyyyyyyyyyyyy";
+        return new JwtTokenManager(longSecretKey);
     }
 
     private String createExpiredToken(Member member) {

--- a/src/test/java/roomescape/auth/JwtTokenManagerTest.java
+++ b/src/test/java/roomescape/auth/JwtTokenManagerTest.java
@@ -2,11 +2,7 @@ package roomescape.auth;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.WeakKeyException;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
 import roomescape.exception.UnAuthorizedException;
@@ -19,11 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static roomescape.auth.JwtTokenManager.ACCESS_TOKEN_EXP;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class JwtTokenManagerTest {
-
-    @Autowired
-    private JwtTokenManager jwtTokenManager;
 
     @Test
     void 시크릿_키_길이가_충분하지_않은경우_예외가_발생한다() {
@@ -36,6 +28,7 @@ class JwtTokenManagerTest {
     void 액세스_토큰을_파싱할_수_있다() {
         // given
         Member member = new Member(1L, "멤버", "member@email.com", Role.USER);
+        JwtTokenManager jwtTokenManager = createJwtTokenManager();
         String accessToken = jwtTokenManager.createAccessToken(member);
         // when
         long resultOfParseToken = jwtTokenManager.parseToken(accessToken);
@@ -47,6 +40,7 @@ class JwtTokenManagerTest {
     void 만료된_토큰을_파싱하면_예외를_반환한다() {
         // given
         Member member = new Member(1L, "멤버", "member@email.com", Role.USER);
+        JwtTokenManager jwtTokenManager = createJwtTokenManager();
         String token = createExpiredToken(member);
         // when & then
         assertThatThrownBy(() -> jwtTokenManager.parseToken(token))
@@ -58,6 +52,7 @@ class JwtTokenManagerTest {
     void 잘못된_서명_토큰을_파싱하면_예외를_반환한다() {
         // given
         Member member = new Member(1L, "멤버", "member@email.com", Role.USER);
+        JwtTokenManager jwtTokenManager = createJwtTokenManager();
         String invalidToken = createInvalidToken(member);
         // when & then
         assertThatThrownBy(() -> jwtTokenManager.parseToken(invalidToken))
@@ -65,7 +60,12 @@ class JwtTokenManagerTest {
                 .hasMessage(ExceptionMessage.INVALID_TOKEN.getMessage());
     }
 
+    private JwtTokenManager createJwtTokenManager() {
+        return new JwtTokenManager("test-secret-keyyyyyyyyyyyyyyyyyyyyy");
+    }
+
     private String createExpiredToken(Member member) {
+        JwtTokenManager jwtTokenManager = createJwtTokenManager();
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() - ACCESS_TOKEN_EXP);
 

--- a/src/test/java/roomescape/auth/JwtTokenManagerTest.java
+++ b/src/test/java/roomescape/auth/JwtTokenManagerTest.java
@@ -61,7 +61,8 @@ class JwtTokenManagerTest {
     }
 
     private JwtTokenManager createJwtTokenManager() {
-        return new JwtTokenManager("test-secret-keyyyyyyyyyyyyyyyyyyyyy");
+        String testSecretKey = "test-secret-keyyyyyyyyyyyyyyyyyyyyy";
+        return new JwtTokenManager(testSecretKey);
     }
 
     private String createExpiredToken(Member member) {

--- a/src/test/java/roomescape/fixture/FixtureConfig.java
+++ b/src/test/java/roomescape/fixture/FixtureConfig.java
@@ -1,0 +1,16 @@
+package roomescape.fixture;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import roomescape.member.repository.MemberRepository;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.repository.TimeRepository;
+
+@TestConfiguration
+public class FixtureConfig {
+
+    @Bean
+    public FixtureGenerator fixtureGenerator(MemberRepository memberRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+        return new FixtureGenerator(memberRepository,timeRepository,themeRepository);
+    }
+}

--- a/src/test/java/roomescape/fixture/FixtureGenerator.java
+++ b/src/test/java/roomescape/fixture/FixtureGenerator.java
@@ -1,0 +1,46 @@
+package roomescape.fixture;
+
+import roomescape.auth.dto.LoginMember;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.Role;
+import roomescape.member.repository.MemberRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.Time;
+import roomescape.time.repository.TimeRepository;
+
+import java.time.LocalTime;
+
+public class FixtureGenerator {
+
+    private final MemberRepository memberRepository;
+    private final TimeRepository timeRepository;
+    private final ThemeRepository themeRepository;
+
+    public FixtureGenerator(MemberRepository memberRepository, TimeRepository timeRepository, ThemeRepository themeRepository) {
+        this.memberRepository = memberRepository;
+        this.timeRepository = timeRepository;
+        this.themeRepository = themeRepository;
+    }
+
+    public Theme createTheme() {
+        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
+        return themeRepository.save(theme);
+    }
+
+    public Time createTime() {
+        Time time = new Time(LocalTime.of(22, 0));
+        return timeRepository.save(time);
+    }
+
+    public LoginMember createLoginMember(String name, String email) {
+        Member member = new Member(name, email, "password", Role.USER);
+        Member savedMember = memberRepository.save(member);
+        return new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
+    }
+
+    public Member createMember(String name, String email) {
+        Member member = new Member(name, email, "password", Role.USER);
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -1,30 +1,27 @@
 package roomescape.reservation.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.annotation.Import;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
-import roomescape.member.domain.Member;
-import roomescape.member.domain.Role;
-import roomescape.member.repository.MemberRepository;
+import roomescape.fixture.FixtureConfig;
+import roomescape.fixture.FixtureGenerator;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.dto.request.ReservationRequest;
 import roomescape.reservation.dto.response.MyReservationResponse;
 import roomescape.reservation.dto.response.ReservationResponse;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.theme.domain.Theme;
-import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
-import roomescape.time.repository.TimeRepository;
 import roomescape.waiting.domain.Status;
 import roomescape.waiting.domain.Waiting;
 import roomescape.waiting.repository.WaitingRepository;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +29,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(FixtureConfig.class)
 class ReservationServiceTest {
+
+    @Autowired
+    private FixtureGenerator fixtureGenerator;
 
     @Autowired
     private ReservationService reservationService;
@@ -41,23 +42,21 @@ class ReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private ThemeRepository themeRepository;
-
-    @Autowired
-    private TimeRepository timeRepository;
-
-    @Autowired
     private WaitingRepository waitingRepository;
+
+    private Theme theme;
+    private Time time;
+
+    @BeforeEach
+    void setUp() {
+        theme = fixtureGenerator.createTheme();
+        time = fixtureGenerator.createTime();
+    }
 
     @Test
     void 관리자가_직접_고객의_예약을_생성할_수_있다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         ReservationRequest request = new ReservationRequest(loginMember.name(), LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
         // when
@@ -74,9 +73,7 @@ class ReservationServiceTest {
     @Test
     void 로그인_정보를_활용하여_예약을_생성할_수_있다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         ReservationRequest request = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
         // when
@@ -93,10 +90,8 @@ class ReservationServiceTest {
     @Test
     void 동일한_날짜_시간_및_테마를_가진_예약이_존재하면_예외가_발생한다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
-        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
-        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+        LoginMember loginMember1 = fixtureGenerator.createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = fixtureGenerator.createLoginMember("멤버2", "member2@email.com");
 
         ReservationRequest request1 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
         reservationService.save(request1, loginMember1);
@@ -111,10 +106,7 @@ class ReservationServiceTest {
     @Test
     void 예약_및_대기_목록을_조회한다() {
         // given
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
-
-        Time time = createTime();
-        Theme theme = createTheme();
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         LocalDate date1 = LocalDate.of(2025, 3, 30);
         Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date1, time, theme);
@@ -136,10 +128,7 @@ class ReservationServiceTest {
     @Test
     void 예약을_취소할_수_있다() {
         // given
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
-
-        Time time = createTime();
-        Theme theme = createTheme();
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
         Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
@@ -155,11 +144,9 @@ class ReservationServiceTest {
     @Test
     void 예약을_취소하면_첫번째_대기멤버가_예약에_성공한다() {
         // given
-        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
-        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+        LoginMember loginMember1 = fixtureGenerator.createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = fixtureGenerator.createLoginMember("멤버2", "member2@email.com");
 
-        Time time = createTime();
-        Theme theme = createTheme();
         LocalDate date = LocalDate.of(2025, 3, 30);
 
         Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
@@ -174,22 +161,6 @@ class ReservationServiceTest {
         assertAll(
                 () -> assertThat(responses).hasSize(1),
                 () -> assertThat(responses).anyMatch(response -> Status.CONFIRMED.getDescription().equals(response.status()))
-                );
-    }
-
-    private Theme createTheme() {
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        return themeRepository.save(theme);
-    }
-
-    private Time createTime() {
-        Time time = new Time(LocalTime.of(22, 0));
-        return timeRepository.save(time);
-    }
-
-    private LoginMember createLoginMember(String name, String email) {
-        Member member = new Member(name, email, "password", Role.USER);
-        Member savedMember = memberRepository.save(member);
-        return new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
+        );
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -40,18 +40,13 @@ class ReservationServiceTest {
 
 
     @Test
-    void 로그인_없이_예약을_생성할_수_있다() {
+    void 관리자가_직접_고객의_예약을_생성할_수_있다() {
         // given
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        Theme savedTheme = themeRepository.save(theme);
+        Theme theme = createTheme();
+        Time time = createTime();
+        Member member = createMember("멤버", "member@email.com", Role.USER);
 
-        Time time = new Time(LocalTime.of(22, 0));
-        Time savedTime = timeRepository.save(time);
-
-        Member member = new Member("멤버", "member@email.com", "password", Role.USER);
-        memberRepository.save(member);
-
-        ReservationRequest request = new ReservationRequest(member.getName(), LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
+        ReservationRequest request = new ReservationRequest(member.getName(), LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
         // when
         ReservationResponse response = reservationService.save(request, null);
         // then
@@ -66,17 +61,12 @@ class ReservationServiceTest {
     @Test
     void 로그인_정보를_활용하여_예약을_생성할_수_있다() {
         // given
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        Theme savedTheme = themeRepository.save(theme);
+        Theme theme = createTheme();
+        Time time = createTime();
+        Member member = createMember("멤버", "member@email.com", Role.USER);
 
-        Time time = new Time(LocalTime.of(22, 0));
-        Time savedTime = timeRepository.save(time);
-
-        Member member = new Member("멤버", "member@email.com", "password", Role.USER);
-        Member savedMember = memberRepository.save(member);
-
-        ReservationRequest request = new ReservationRequest(null, LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
-        LoginMember loginMember = new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
+        ReservationRequest request = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
         // when
         ReservationResponse response = reservationService.save(request, loginMember);
         // then
@@ -91,26 +81,35 @@ class ReservationServiceTest {
     @Test
     void 동일한_날짜_시간_및_테마를_가진_예약이_존재하면_예외가_발생한다() {
         // given
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        Theme savedTheme = themeRepository.save(theme);
+        Theme theme = createTheme();
+        Time time = createTime();
+        Member member1 = createMember("멤버1", "member1@email.com", Role.USER);
+        Member member2 = createMember("멤버2", "member2@email.com", Role.USER);
 
-        Time time = new Time(LocalTime.of(22, 0));
-        Time savedTime = timeRepository.save(time);
-
-        Member member1 = new Member("멤버1", "member1@email.com", "password", Role.USER);
-        Member savedMember1 = memberRepository.save(member1);
-        Member member2 = new Member("멤버2", "member2@email.com", "password", Role.USER);
-        Member savedMember2 = memberRepository.save(member2);
-
-        ReservationRequest request1 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
-        LoginMember loginMember1 = new LoginMember(savedMember1.getId(), savedMember1.getName(), savedMember1.getEmail(), savedMember1.getRole());
+        ReservationRequest request1 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
+        LoginMember loginMember1 = new LoginMember(member1.getId(), member1.getName(), member1.getEmail(), member1.getRole());
         reservationService.save(request1, loginMember1);
 
-        ReservationRequest request2 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
-        LoginMember loginMember2 = new LoginMember(savedMember2.getId(), savedMember2.getName(), savedMember2.getEmail(), savedMember2.getRole());
+        ReservationRequest request2 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
+        LoginMember loginMember2 = new LoginMember(member2.getId(), member2.getName(), member2.getEmail(), member2.getRole());
         // when & then
         assertThatThrownBy(() -> reservationService.save(request2, loginMember2))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+    }
+
+    private Theme createTheme() {
+        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
+        return themeRepository.save(theme);
+    }
+
+    private Time createTime() {
+        Time time = new Time(LocalTime.of(22, 0));
+        return timeRepository.save(time);
+    }
+
+    private Member createMember(String name, String email, Role role) {
+        Member member = new Member(name, email, "password", role);
+        return memberRepository.save(member);
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -3,21 +3,29 @@ package roomescape.reservation.service;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.Role;
 import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.dto.request.ReservationRequest;
+import roomescape.reservation.dto.response.MyReservationResponse;
 import roomescape.reservation.dto.response.ReservationResponse;
+import roomescape.reservation.repository.ReservationRepository;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
 import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.domain.Status;
+import roomescape.waiting.domain.Waiting;
+import roomescape.waiting.repository.WaitingRepository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +38,9 @@ class ReservationServiceTest {
     private ReservationService reservationService;
 
     @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -38,20 +49,22 @@ class ReservationServiceTest {
     @Autowired
     private TimeRepository timeRepository;
 
+    @Autowired
+    private WaitingRepository waitingRepository;
 
     @Test
     void 관리자가_직접_고객의_예약을_생성할_수_있다() {
         // given
         Theme theme = createTheme();
         Time time = createTime();
-        Member member = createMember("멤버", "member@email.com", Role.USER);
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
 
-        ReservationRequest request = new ReservationRequest(member.getName(), LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
+        ReservationRequest request = new ReservationRequest(loginMember.name(), LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
         // when
         ReservationResponse response = reservationService.save(request, null);
         // then
         assertAll(
-                () -> assertThat(response.getName()).isEqualTo(member.getName()),
+                () -> assertThat(response.getName()).isEqualTo(loginMember.name()),
                 () -> assertThat(response.getTheme()).isEqualTo(theme.getName()),
                 () -> assertThat(response.getDate()).isEqualTo(request.getDate()),
                 () -> assertThat(response.getTime()).isEqualTo(time.getValue())
@@ -63,10 +76,9 @@ class ReservationServiceTest {
         // given
         Theme theme = createTheme();
         Time time = createTime();
-        Member member = createMember("멤버", "member@email.com", Role.USER);
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
 
         ReservationRequest request = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
-        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
         // when
         ReservationResponse response = reservationService.save(request, loginMember);
         // then
@@ -83,19 +95,88 @@ class ReservationServiceTest {
         // given
         Theme theme = createTheme();
         Time time = createTime();
-        Member member1 = createMember("멤버1", "member1@email.com", Role.USER);
-        Member member2 = createMember("멤버2", "member2@email.com", Role.USER);
+        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
 
         ReservationRequest request1 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
-        LoginMember loginMember1 = new LoginMember(member1.getId(), member1.getName(), member1.getEmail(), member1.getRole());
         reservationService.save(request1, loginMember1);
 
         ReservationRequest request2 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), theme.getId(), time.getId());
-        LoginMember loginMember2 = new LoginMember(member2.getId(), member2.getName(), member2.getEmail(), member2.getRole());
         // when & then
         assertThatThrownBy(() -> reservationService.save(request2, loginMember2))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    @Transactional(readOnly = true)
+    void 예약_및_대기_목록을_조회한다() {
+        // given
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+
+        Time time = createTime();
+        Theme theme = createTheme();
+
+        LocalDate date1 = LocalDate.of(2025, 3, 30);
+        Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date1, time, theme);
+        reservationRepository.save(reservation);
+
+        LocalDate date2 = LocalDate.of(2025, 3, 31);
+        Waiting waiting = new Waiting(loginMember.id(), loginMember.name(), date2, time, theme);
+        waitingRepository.save(waiting);
+        // when
+        List<MyReservationResponse> responses = reservationService.findMyReservations(loginMember);
+        // then
+        assertAll(
+                () -> assertThat(responses).hasSize(2),
+                () -> assertThat(responses).anyMatch(response -> response.id() == (reservation.getId())),
+                () -> assertThat(responses).anyMatch(response -> response.id() == (waiting.getId()))
+        );
+    }
+
+    @Test
+    void 예약을_취소할_수_있다() {
+        // given
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+
+        Time time = createTime();
+        Theme theme = createTheme();
+
+        LocalDate date = LocalDate.of(2025, 3, 30);
+        Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
+        reservationRepository.save(reservation);
+
+        // when
+        reservationService.delete(reservation.getId());
+        // then
+        List<MyReservationResponse> responses = reservationService.findMyReservations(loginMember);
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void 예약을_취소하면_첫번째_대기멤버가_예약에_성공한다() {
+        // given
+        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+
+        Time time = createTime();
+        Theme theme = createTheme();
+        LocalDate date = LocalDate.of(2025, 3, 30);
+
+        Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
+        reservationRepository.save(reservation);
+
+        Waiting waiting = new Waiting(loginMember2.id(), loginMember2.name(), date, time, theme);
+        waitingRepository.save(waiting);
+        // when
+        reservationService.delete(reservation.getId());
+        // then
+        List<MyReservationResponse> responses = reservationService.findMyReservations(loginMember2);
+        assertAll(
+                () -> assertThat(responses).hasSize(1),
+                () -> assertThat(responses).anyMatch(response -> Status.CONFIRMED.getDescription().equals(response.status()))
+                );
     }
 
     private Theme createTheme() {
@@ -108,8 +189,9 @@ class ReservationServiceTest {
         return timeRepository.save(time);
     }
 
-    private Member createMember(String name, String email, Role role) {
-        Member member = new Member(name, email, "password", role);
-        return memberRepository.save(member);
+    private LoginMember createLoginMember(String name, String email) {
+        Member member = new Member(name, email, "password", Role.USER);
+        Member savedMember = memberRepository.save(member);
+        return new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -109,7 +109,6 @@ class ReservationServiceTest {
     }
 
     @Test
-    @Transactional(readOnly = true)
     void 예약_및_대기_목록을_조회한다() {
         // given
         LoginMember loginMember = createLoginMember("멤버", "member@email.com");
@@ -154,7 +153,6 @@ class ReservationServiceTest {
     }
 
     @Test
-    @Transactional
     void 예약을_취소하면_첫번째_대기멤버가_예약에_성공한다() {
         // given
         LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import roomescape.auth.dto.LoginMember;
+import roomescape.exception.BadRequestException;
+import roomescape.exception.ExceptionMessage;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.Role;
 import roomescape.member.repository.MemberRepository;
@@ -18,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -83,5 +86,31 @@ class ReservationServiceTest {
                 () -> assertThat(response.getDate()).isEqualTo(request.getDate()),
                 () -> assertThat(response.getTime()).isEqualTo(time.getValue())
         );
+    }
+
+    @Test
+    void 동일한_날짜_시간_및_테마를_가진_예약이_존재하면_예외가_발생한다() {
+        // given
+        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
+        Theme savedTheme = themeRepository.save(theme);
+
+        Time time = new Time(LocalTime.of(22, 0));
+        Time savedTime = timeRepository.save(time);
+
+        Member member1 = new Member("멤버1", "member1@email.com", "password", Role.USER);
+        Member savedMember1 = memberRepository.save(member1);
+        Member member2 = new Member("멤버2", "member2@email.com", "password", Role.USER);
+        Member savedMember2 = memberRepository.save(member2);
+
+        ReservationRequest request1 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
+        LoginMember loginMember1 = new LoginMember(savedMember1.getId(), savedMember1.getName(), savedMember1.getEmail(), savedMember1.getRole());
+        reservationService.save(request1, loginMember1);
+
+        ReservationRequest request2 = new ReservationRequest(null, LocalDate.of(2025, 3, 15), savedTheme.getId(), savedTime.getId());
+        LoginMember loginMember2 = new LoginMember(savedMember2.getId(), savedMember2.getName(), savedMember2.getEmail(), savedMember2.getRole());
+        // when & then
+        assertThatThrownBy(() -> reservationService.save(request2, loginMember2))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
     }
 }

--- a/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
@@ -1,8 +1,12 @@
 package roomescape.waiting.repository;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import roomescape.fixture.FixtureConfig;
+import roomescape.fixture.FixtureGenerator;
 import roomescape.member.domain.Member;
 import roomescape.member.domain.Role;
 import roomescape.member.repository.MemberRepository;
@@ -11,39 +15,38 @@ import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
 import roomescape.time.repository.TimeRepository;
 import roomescape.waiting.domain.Waiting;
-import roomescape.waiting.domain.WaitingWithRank;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
+@Import(FixtureConfig.class)
 class WaitingRepositoryTest {
+
+    @Autowired
+    private FixtureGenerator fixtureGenerator;
 
     @Autowired
     private WaitingRepository waitingRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
+    private Theme theme;
+    private Time time;
 
-    @Autowired
-    private ThemeRepository themeRepository;
-
-    @Autowired
-    private TimeRepository timeRepository;
+    @BeforeEach
+    void setUp() {
+        theme = fixtureGenerator.createTheme();
+        time = fixtureGenerator.createTime();
+    }
 
     @Test
     void 예약_대기_신청이_중복되었으면_true를_반환한다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
         LocalDate date = LocalDate.of(2025, 3, 30);
 
-        Member member = createMember("멤버", "member@email.com");
+        Member member = fixtureGenerator.createMember("멤버", "member@email.com");
         Waiting waiting = new Waiting(member.getId(), member.getName(), date, time, theme);
         waitingRepository.save(waiting);
         // when
@@ -55,15 +58,13 @@ class WaitingRepositoryTest {
     @Test
     void 멤버의_예약_대기_순서를_조회한다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
         LocalDate date = LocalDate.of(2025, 3, 30);
 
-        Member member1 = createMember("멤버1", "member1@email.com");
+        Member member1 = fixtureGenerator.createMember("멤버1", "member1@email.com");
         Waiting waiting1 = new Waiting(member1.getId(), member1.getName(), date, time, theme);
         waitingRepository.save(waiting1);
 
-        Member member2 = createMember("멤버2", "member2@email.com");
+        Member member2 = fixtureGenerator.createMember("멤버2", "member2@email.com");
         Waiting waiting2 = new Waiting(member2.getId(), member2.getName(), date, time, theme);
         waitingRepository.save(waiting2);
         // when
@@ -75,15 +76,13 @@ class WaitingRepositoryTest {
     @Test
     void 특정_날짜_시간_테마에_해당하는_첫번째_대기를_조회한다() {
         // given
-        Theme theme = createTheme();
-        Time time = createTime();
         LocalDate date = LocalDate.of(2025, 3, 30);
 
-        Member member1 = createMember("멤버1", "member1@email.com");
+        Member member1 = fixtureGenerator.createMember("멤버1", "member1@email.com");
         Waiting waiting1 = new Waiting(member1.getId(), member1.getName(), date, time, theme);
         waitingRepository.save(waiting1);
 
-        Member member2 = createMember("멤버2", "member2@email.com");
+        Member member2 = fixtureGenerator.createMember("멤버2", "member2@email.com");
         Waiting waiting2 = new Waiting(member2.getId(), member2.getName(), date, time, theme);
         waitingRepository.save(waiting2);
         // when
@@ -92,20 +91,5 @@ class WaitingRepositoryTest {
         assertThat(expectedFirstWaiting).hasValueSatisfying(
                 waiting -> waiting.getMemberId().equals(member1.getId())
         );
-    }
-
-    private Theme createTheme() {
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        return themeRepository.save(theme);
-    }
-
-    private Time createTime() {
-        Time time = new Time(LocalTime.of(22, 0));
-        return timeRepository.save(time);
-    }
-
-    private Member createMember(String name, String email) {
-        Member member = new Member(name, email, "password", Role.USER);
-        return memberRepository.save(member);
     }
 }

--- a/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
@@ -73,29 +73,6 @@ class WaitingRepositoryTest {
     }
 
     @Test
-    void 멤버의_대기중인_예약_목록을_조회한다() {
-        // given
-        Member member = createMember("멤버", "member@email.com");
-        Theme theme = createTheme();
-        Time time = createTime();
-        LocalDate date1 = LocalDate.of(2025, 3, 30);
-        LocalDate date2 = LocalDate.of(2025, 3, 31);
-
-        Waiting waiting1 = new Waiting(member.getId(), member.getName(), date1, time, theme);
-        Waiting waiting2 = new Waiting(member.getId(), member.getName(), date2, time, theme);
-        waitingRepository.save(waiting1);
-        waitingRepository.save(waiting2);
-        // when
-        List<WaitingWithRank> waitings = waitingRepository.findWaitingsWithRankByMemberId(member.getId());
-        // then
-        assertAll(
-                () -> assertThat(waitings).hasSize(2),
-                () -> assertThat(waitings.get(0).getMemberId()).isEqualTo(member.getId()),
-                () -> assertThat(waitings.get(1).getMemberId()).isEqualTo(member.getId())
-        );
-    }
-
-    @Test
     void 특정_날짜_시간_테마에_해당하는_첫번째_대기를_조회한다() {
         // given
         Theme theme = createTheme();

--- a/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/roomescape/waiting/repository/WaitingRepositoryTest.java
@@ -1,0 +1,134 @@
+package roomescape.waiting.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.Role;
+import roomescape.member.repository.MemberRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.Time;
+import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.domain.Waiting;
+import roomescape.waiting.domain.WaitingWithRank;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+class WaitingRepositoryTest {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ThemeRepository themeRepository;
+
+    @Autowired
+    private TimeRepository timeRepository;
+
+    @Test
+    void 예약_대기_신청이_중복되었으면_true를_반환한다() {
+        // given
+        Theme theme = createTheme();
+        Time time = createTime();
+        LocalDate date = LocalDate.of(2025, 3, 30);
+
+        Member member = createMember("멤버", "member@email.com");
+        Waiting waiting = new Waiting(member.getId(), member.getName(), date, time, theme);
+        waitingRepository.save(waiting);
+        // when
+        boolean isDuplicateWaiting = waitingRepository.existsByMemberIdAndDateAndTimeAndTheme(member.getId(), LocalDate.of(2025, 3, 30), time, theme);
+        // then
+        assertThat(isDuplicateWaiting).isTrue();
+    }
+
+    @Test
+    void 멤버의_예약_대기_순서를_조회한다() {
+        // given
+        Theme theme = createTheme();
+        Time time = createTime();
+        LocalDate date = LocalDate.of(2025, 3, 30);
+
+        Member member1 = createMember("멤버1", "member1@email.com");
+        Waiting waiting1 = new Waiting(member1.getId(), member1.getName(), date, time, theme);
+        waitingRepository.save(waiting1);
+
+        Member member2 = createMember("멤버2", "member2@email.com");
+        Waiting waiting2 = new Waiting(member2.getId(), member2.getName(), date, time, theme);
+        waitingRepository.save(waiting2);
+        // when
+        Long rankOfMember2 = waitingRepository.findWaitingNumberByMemberId(member2.getId());
+        // then
+        assertThat(rankOfMember2).isEqualTo(2);
+    }
+
+    @Test
+    void 멤버의_대기중인_예약_목록을_조회한다() {
+        // given
+        Member member = createMember("멤버", "member@email.com");
+        Theme theme = createTheme();
+        Time time = createTime();
+        LocalDate date1 = LocalDate.of(2025, 3, 30);
+        LocalDate date2 = LocalDate.of(2025, 3, 31);
+
+        Waiting waiting1 = new Waiting(member.getId(), member.getName(), date1, time, theme);
+        Waiting waiting2 = new Waiting(member.getId(), member.getName(), date2, time, theme);
+        waitingRepository.save(waiting1);
+        waitingRepository.save(waiting2);
+        // when
+        List<WaitingWithRank> waitings = waitingRepository.findWaitingsWithRankByMemberId(member.getId());
+        // then
+        assertAll(
+                () -> assertThat(waitings).hasSize(2),
+                () -> assertThat(waitings.get(0).getMemberId()).isEqualTo(member.getId()),
+                () -> assertThat(waitings.get(1).getMemberId()).isEqualTo(member.getId())
+        );
+    }
+
+    @Test
+    void 특정_날짜_시간_테마에_해당하는_첫번째_대기를_조회한다() {
+        // given
+        Theme theme = createTheme();
+        Time time = createTime();
+        LocalDate date = LocalDate.of(2025, 3, 30);
+
+        Member member1 = createMember("멤버1", "member1@email.com");
+        Waiting waiting1 = new Waiting(member1.getId(), member1.getName(), date, time, theme);
+        waitingRepository.save(waiting1);
+
+        Member member2 = createMember("멤버2", "member2@email.com");
+        Waiting waiting2 = new Waiting(member2.getId(), member2.getName(), date, time, theme);
+        waitingRepository.save(waiting2);
+        // when
+        Optional<Waiting> expectedFirstWaiting = waitingRepository.findFirstWaitingByDateAndTimeAndTheme(date, time, theme);
+        // then
+        assertThat(expectedFirstWaiting).hasValueSatisfying(
+                waiting -> waiting.getMemberId().equals(member1.getId())
+        );
+    }
+
+    private Theme createTheme() {
+        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
+        return themeRepository.save(theme);
+    }
+
+    private Time createTime() {
+        Time time = new Time(LocalTime.of(22, 0));
+        return timeRepository.save(time);
+    }
+
+    private Member createMember(String name, String email) {
+        Member member = new Member(name, email, "password", Role.USER);
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
@@ -1,0 +1,116 @@
+package roomescape.waiting.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import roomescape.auth.dto.LoginMember;
+import roomescape.exception.BadRequestException;
+import roomescape.exception.ExceptionMessage;
+import roomescape.member.domain.Member;
+import roomescape.member.domain.Role;
+import roomescape.member.repository.MemberRepository;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.repository.ReservationRepository;
+import roomescape.theme.domain.Theme;
+import roomescape.theme.repository.ThemeRepository;
+import roomescape.time.domain.Time;
+import roomescape.time.repository.TimeRepository;
+import roomescape.waiting.dto.request.WaitingRequest;
+import roomescape.waiting.dto.response.WaitingResponse;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class WaitingServiceTest {
+
+    @Autowired
+    private WaitingService waitingService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ThemeRepository themeRepository;
+
+    @Autowired
+    private TimeRepository timeRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Test
+    void 예약_대기를_신청할_수_있다() {
+        // given
+        Member member = createMember("멤버", "member@email.com");
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+
+        LocalDate date = LocalDate.of(2025, 3, 30);
+        Time time = createTime();
+        Theme theme = createTheme();
+        WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
+
+        int expectedWaitingNumber = 1;
+        // when
+        WaitingResponse response = waitingService.createWaiting(request, loginMember);
+        // then
+        assertThat(response.waitingNumber()).isEqualTo(expectedWaitingNumber);
+    }
+
+    @Test
+    void 이미_예약을_한_상태에서_예약_대기를_신청하면_예외가_발생한다() {
+        // given
+        Member member = createMember("멤버", "member@email.com");
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+
+        LocalDate date = LocalDate.of(2025, 3, 30);
+        Time time = createTime();
+        Theme theme = createTheme();
+
+        Reservation reservation = new Reservation(member.getId(), member.getName(), date, time, theme);
+        reservationRepository.save(reservation);
+
+        WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
+        // when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    void 예약_대기를_중복으로_신청하면_예외가_발생한다() {
+        // given
+        Member member = createMember("멤버", "member@email.com");
+        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+
+        LocalDate date = LocalDate.of(2025, 3, 30);
+        Time time = createTime();
+        Theme theme = createTheme();
+
+        WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
+        waitingService.createWaiting(request, loginMember);
+
+        // when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
+    }
+
+    private Theme createTheme() {
+        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
+        return themeRepository.save(theme);
+    }
+
+    private Time createTime() {
+        Time time = new Time(LocalTime.of(22, 0));
+        return timeRepository.save(time);
+    }
+
+    private Member createMember(String name, String email) {
+        Member member = new Member(name, email, "password", Role.USER);
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
@@ -45,32 +45,50 @@ class WaitingServiceTest {
     @Test
     void 예약_대기를_신청할_수_있다() {
         // given
-        Member member = createMember("멤버", "member@email.com");
-        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+
+        LocalDate date = LocalDate.of(2025, 3, 30);
+        Time time = createTime();
+        Theme theme = createTheme();
+
+        Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
+        reservationRepository.save(reservation);
+
+        WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
+        int expectedWaitingNumber = 1;
+        // when
+        WaitingResponse response = waitingService.createWaiting(request, loginMember2);
+        // then
+        assertThat(response.waitingNumber()).isEqualTo(expectedWaitingNumber);
+    }
+
+    @Test
+    void 예약이_존재하지_않는_상태에서_대기를_신청하면_예외가_발생한다() {
+        // given
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
         Time time = createTime();
         Theme theme = createTheme();
         WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
 
-        int expectedWaitingNumber = 1;
-        // when
-        WaitingResponse response = waitingService.createWaiting(request, loginMember);
-        // then
-        assertThat(response.waitingNumber()).isEqualTo(expectedWaitingNumber);
+        // when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ExceptionMessage.RESERVATION_NOT_FOUND.getMessage());
     }
 
     @Test
     void 이미_예약을_한_상태에서_예약_대기를_신청하면_예외가_발생한다() {
         // given
-        Member member = createMember("멤버", "member@email.com");
-        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
         Time time = createTime();
         Theme theme = createTheme();
 
-        Reservation reservation = new Reservation(member.getId(), member.getName(), date, time, theme);
+        Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
         reservationRepository.save(reservation);
 
         WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
@@ -83,18 +101,21 @@ class WaitingServiceTest {
     @Test
     void 예약_대기를_중복으로_신청하면_예외가_발생한다() {
         // given
-        Member member = createMember("멤버", "member@email.com");
-        LoginMember loginMember = new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
         Time time = createTime();
         Theme theme = createTheme();
 
+        Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
+        reservationRepository.save(reservation);
+
         WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
-        waitingService.createWaiting(request, loginMember);
+        waitingService.createWaiting(request, loginMember2);
 
         // when & then
-        assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember))
+        assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember2))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
     }
@@ -109,8 +130,9 @@ class WaitingServiceTest {
         return timeRepository.save(time);
     }
 
-    private Member createMember(String name, String email) {
+    private LoginMember createLoginMember(String name, String email) {
         Member member = new Member(name, email, "password", Role.USER);
-        return memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
+        return new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
     }
 }

--- a/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/roomescape/waiting/service/WaitingServiceTest.java
@@ -1,56 +1,56 @@
 package roomescape.waiting.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import roomescape.auth.dto.LoginMember;
 import roomescape.exception.BadRequestException;
 import roomescape.exception.ExceptionMessage;
-import roomescape.member.domain.Member;
-import roomescape.member.domain.Role;
-import roomescape.member.repository.MemberRepository;
+import roomescape.fixture.FixtureConfig;
+import roomescape.fixture.FixtureGenerator;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.repository.ReservationRepository;
 import roomescape.theme.domain.Theme;
-import roomescape.theme.repository.ThemeRepository;
 import roomescape.time.domain.Time;
-import roomescape.time.repository.TimeRepository;
 import roomescape.waiting.dto.request.WaitingRequest;
 import roomescape.waiting.dto.response.WaitingResponse;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(FixtureConfig.class)
 class WaitingServiceTest {
+
+    @Autowired
+    private FixtureGenerator fixtureGenerator;
 
     @Autowired
     private WaitingService waitingService;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private ThemeRepository themeRepository;
-
-    @Autowired
-    private TimeRepository timeRepository;
-
-    @Autowired
     private ReservationRepository reservationRepository;
+
+    private Theme theme;
+    private Time time;
+
+    @BeforeEach
+    void setUp() {
+        theme = fixtureGenerator.createTheme();
+        time = fixtureGenerator.createTime();
+    }
 
     @Test
     void 예약_대기를_신청할_수_있다() {
         // given
-        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
-        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+        LoginMember loginMember1 = fixtureGenerator.createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = fixtureGenerator.createLoginMember("멤버2", "member2@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
-        Time time = createTime();
-        Theme theme = createTheme();
 
         Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
         reservationRepository.save(reservation);
@@ -66,11 +66,9 @@ class WaitingServiceTest {
     @Test
     void 예약이_존재하지_않는_상태에서_대기를_신청하면_예외가_발생한다() {
         // given
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
-        Time time = createTime();
-        Theme theme = createTheme();
         WaitingRequest request = new WaitingRequest(date, time.getId(), theme.getId());
 
         // when & then
@@ -82,11 +80,9 @@ class WaitingServiceTest {
     @Test
     void 이미_예약을_한_상태에서_예약_대기를_신청하면_예외가_발생한다() {
         // given
-        LoginMember loginMember = createLoginMember("멤버", "member@email.com");
+        LoginMember loginMember = fixtureGenerator.createLoginMember("멤버", "member@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
-        Time time = createTime();
-        Theme theme = createTheme();
 
         Reservation reservation = new Reservation(loginMember.id(), loginMember.name(), date, time, theme);
         reservationRepository.save(reservation);
@@ -101,12 +97,10 @@ class WaitingServiceTest {
     @Test
     void 예약_대기를_중복으로_신청하면_예외가_발생한다() {
         // given
-        LoginMember loginMember1 = createLoginMember("멤버1", "member1@email.com");
-        LoginMember loginMember2 = createLoginMember("멤버2", "member2@email.com");
+        LoginMember loginMember1 = fixtureGenerator.createLoginMember("멤버1", "member1@email.com");
+        LoginMember loginMember2 = fixtureGenerator.createLoginMember("멤버2", "member2@email.com");
 
         LocalDate date = LocalDate.of(2025, 3, 30);
-        Time time = createTime();
-        Theme theme = createTheme();
 
         Reservation reservation = new Reservation(loginMember1.id(), loginMember1.name(), date, time, theme);
         reservationRepository.save(reservation);
@@ -118,21 +112,5 @@ class WaitingServiceTest {
         assertThatThrownBy(() -> waitingService.createWaiting(request, loginMember2))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ExceptionMessage.WAITING_ALREADY_EXISTS.getMessage());
-    }
-
-    private Theme createTheme() {
-        Theme theme = new Theme("커스텀테마1", "커스텀테마 입니다.");
-        return themeRepository.save(theme);
-    }
-
-    private Time createTime() {
-        Time time = new Time(LocalTime.of(22, 0));
-        return timeRepository.save(time);
-    }
-
-    private LoginMember createLoginMember(String name, String email) {
-        Member member = new Member(name, email, "password", Role.USER);
-        Member savedMember = memberRepository.save(member);
-        return new LoginMember(savedMember.getId(), savedMember.getName(), savedMember.getEmail(), savedMember.getRole());
     }
 }


### PR DESCRIPTION
안녕하세요 짱수! 
이번 미션은 저번보다 난이도가 있어 구현하는데 시간이 좀 더 걸렸네요😅
최대한 가독성 좋게 작성하려고 노력했지만,,, 개선할 곳이 보인다면 리뷰 마구마구 부탁드립니다!
또한 리뷰해 주셔서 감사합니다☺️

## 🛠️ 주요 변경사항 및 고려한 부분

- **예약 생성 기능 리팩토링**
  - 관리자/일반 페이지에 따른 예약 생성 방법:
  원래는 관리자가 예약 생성할 수 있는 API를 추가하려 했습니다. 하지만 아래 요구사항이 뭔가 하나의 API를 사용하여 해결하라는 느낌이 들어 `ReservationRequest` 클래스만 리팩토링 하였습니다.

    > 관리자가 어드민 화면에서 예약을 생성하는 경우 name 값을 string으로 전달합니다.
사용자가 예약 화면에서 예약을 생성하는 경우 로그인 정보를 이용하여 Member의 ID를 Reservation에 저장하도록 합니다.
  - 중복 예약이 불가능 하도록 검증 추가

- **내 예약 목록 조회 API 추가**
  - 예약 목록 조회 시 현재 예약 상태(예약 또는 몇번째 대기 상태인지) 확인하는 기능 구현 
  - Waiting 엔티티 생성

- **예약 취소 시 첫번째 대기 멤버 `대기 -> 예약` 상태로 전환**

- **예약 대기 요청 & 취소 API 추가**
  - 예약 대기 요청
    - 예약 상태가 아닌데 예약 대기 요청하는지에 대한 검증 추가
    - 중복으로 예약 대기 요청하였는지에 대한 검증 추가

- **JwtTokenManagerTest 단위 테스트로 변경**
  - JwtTokenManager가 외부 의존성이 없고, secret key를 받아 메서드를 수행하는 클래스이기 때문에 `@SpringBootTest`를 제거하였습니다!

## 🙋🏻‍♀️ 질문

- `ReservationService`내 createReservation(ReservationRequest reservationRequest, LoginMember loginMember) 메서드
  - 현재 관리자 페이지 진입시 interceptor를 통해 관리자가 아니면 예외를 띄우고 있습니다.
따라서 `createReservation()` 호출 시 로그인한 유저가 이미 관리자임이 검증된 상태인데요.
이 때 **관리자만 호출할 수 있는 `reservationRequest.toReservationByAdmin()` 메서드를 호출 하기 전에 관리자 검증을 한 번 더 하는게 좋을까요?**

- `Waiting` & `Reservation` 과 `Member` 연관관계 설계
  - member와 연관관계를 맺을지 말지 엄청 고민하였는데요,,,
Member와 연관관계를 맺지 않고 ID와 Name을 직접 저장하면 fk설정이 필요 없어 단순하며, 조인 없이 데이터를 빠르게 가져올 수 있는 점이 다른 단점보다 더 크다고 생각하여 연관관계를 맺지 않았습니다!
하지만 후에 요구사항이 더 늘어나 id, name외 다른 데이터들도 필요할 가능성이 있으니 **연관관계를 맺어 두는게 더 나을까요?
만약 짱수라면 어떤 이유로 어떤 방식을 택할지 궁금합니다ㅎㅎ**

- `ReservationService` 내 findMyReservations 메서드
  - `ReservationService` 내 findMyReservations 메서드에서 Lazy 로딩을 시도할 때 프로덕션 코드에서는 정상적으로 작동하는데, 테스트 코드에서는 `LazyInitializationException`이 발생합니다.
  **동일한 코드인데 왜 테스트 환경에서만 예외가 발생하는 걸까요..?** 프로덕션 코드 내에서도 `@Transactional` 을 따로 사용하지 않고 있는데 말이죠,,!
  (프로덕션 코드에 `@Transactional` 붙이면 테스트가 잘 통과되긴 합니다.)