### PR TITLE
[Spring MVC(인증)] 권장순 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/login/AdminInterceptor.java
+++ b/src/main/java/roomescape/login/AdminInterceptor.java
@@ -1,0 +1,47 @@
+package roomescape.login;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class AdminInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    public AdminInterceptor(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        Optional<String> tokenOptional = Arrays.stream(cookies)
+                .filter(cookie -> "token".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+
+        if (tokenOptional.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        String token = tokenOptional.get();
+        String role = jwtUtil.getRoleFromToken(token);
+
+        if (!"ADMIN".equals(role)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/roomescape/login/AdminInterceptor.java
+++ b/src/main/java/roomescape/login/AdminInterceptor.java
@@ -6,11 +6,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 public class AdminInterceptor implements HandlerInterceptor {
 
     private final JwtUtil jwtUtil;
+    private static final String ADMIN_ROLE = "ADMIN";
+    private static final String TOKEN_COOKIE_NAME = "token";
 
     public AdminInterceptor(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
@@ -24,20 +25,13 @@ public class AdminInterceptor implements HandlerInterceptor {
             return false;
         }
 
-        Optional<String> tokenOptional = Arrays.stream(cookies)
-                .filter(cookie -> "token".equals(cookie.getName()))
+        boolean isAdmin = Arrays.stream(cookies)
+                .filter(cookie -> TOKEN_COOKIE_NAME.equals(cookie.getName()))
                 .map(Cookie::getValue)
-                .findFirst();
+                .map(jwtUtil::getRoleFromToken)
+                .anyMatch(ADMIN_ROLE::equals);
 
-        if (tokenOptional.isEmpty()) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return false;
-        }
-
-        String token = tokenOptional.get();
-        String role = jwtUtil.getRoleFromToken(token);
-
-        if (!"ADMIN".equals(role)) {
+        if (!isAdmin) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
         }

--- a/src/main/java/roomescape/login/JwtUtil.java
+++ b/src/main/java/roomescape/login/JwtUtil.java
@@ -31,6 +31,10 @@ public class JwtUtil {
         return parseClaims(token).getSubject();
     }
 
+    public String getRoleFromToken(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)

--- a/src/main/java/roomescape/login/JwtUtil.java
+++ b/src/main/java/roomescape/login/JwtUtil.java
@@ -1,0 +1,41 @@
+package roomescape.login;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+import roomescape.member.Member;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+
+    public JwtUtil() {
+        String secretKeyString = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createToken(Member member) {
+        return Jwts.builder()
+                .setSubject(member.getId().toString())
+                .claim("name", member.getName())
+                .claim("role", member.getRole())
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getNameFromToken(String token) {
+        return parseClaims(token).get("name", String.class);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/roomescape/login/JwtUtil.java
+++ b/src/main/java/roomescape/login/JwtUtil.java
@@ -27,8 +27,8 @@ public class JwtUtil {
                 .compact();
     }
 
-    public String getNameFromToken(String token) {
-        return parseClaims(token).get("name", String.class);
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
     }
 
     private Claims parseClaims(String token) {
@@ -39,3 +39,4 @@ public class JwtUtil {
                 .getBody();
     }
 }
+

--- a/src/main/java/roomescape/login/JwtUtil.java
+++ b/src/main/java/roomescape/login/JwtUtil.java
@@ -3,6 +3,7 @@ package roomescape.login;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import roomescape.member.Member;
 
@@ -13,8 +14,7 @@ import java.nio.charset.StandardCharsets;
 public class JwtUtil {
     private final SecretKey secretKey;
 
-    public JwtUtil() {
-        String secretKeyString = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+    public JwtUtil(@Value("${jwt.secret.key}") String secretKeyString) {
         this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -31,6 +31,8 @@ public class JwtUtil {
         return parseClaims(token).getSubject();
     }
 
+
+
     public String getRoleFromToken(String token) {
         return parseClaims(token).get("role", String.class);
     }
@@ -43,4 +45,3 @@ public class JwtUtil {
                 .getBody();
     }
 }
-

--- a/src/main/java/roomescape/login/LoginController.java
+++ b/src/main/java/roomescape/login/LoginController.java
@@ -3,7 +3,6 @@ package roomescape.login;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,11 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class LoginController {
 
     private final LoginService loginService;
-    private final JwtUtil jwtUtil;
 
-    public LoginController(LoginService loginService, JwtUtil jwtUtil) {
+    public LoginController(LoginService loginService) {
         this.loginService = loginService;
-        this.jwtUtil = jwtUtil;
     }
 
     @PostMapping("/login")
@@ -33,13 +30,7 @@ public class LoginController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity<LoginResponse> checkLogin(@CookieValue(name = "token", required = false) String token) {
-        if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("[ERROR] 토큰이 존재하지 않습니다.");
-        }
-
-        String name = jwtUtil.getNameFromToken(token);
-
-        return ResponseEntity.ok(new LoginResponse(name));
+    public ResponseEntity<LoginResponse> checkLogin(LoginMember loginMember) {
+        return ResponseEntity.ok(new LoginResponse(loginMember.name()));
     }
 }

--- a/src/main/java/roomescape/login/LoginController.java
+++ b/src/main/java/roomescape/login/LoginController.java
@@ -1,7 +1,7 @@
 package roomescape.login;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,15 +18,17 @@ public class LoginController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
         String token = loginService.login(loginRequest.email(), loginRequest.password());
 
-        Cookie cookie = new Cookie("token", token);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from("token", token)
+                .path("/")
+                .httpOnly(true)
+                .build();
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .build();
     }
 
     @GetMapping("/login/check")

--- a/src/main/java/roomescape/login/LoginController.java
+++ b/src/main/java/roomescape/login/LoginController.java
@@ -1,0 +1,45 @@
+package roomescape.login;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+
+    private final LoginService loginService;
+    private final JwtUtil jwtUtil;
+
+    public LoginController(LoginService loginService, JwtUtil jwtUtil) {
+        this.loginService = loginService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+        String token = loginService.login(loginRequest.email(), loginRequest.password());
+
+        Cookie cookie = new Cookie("token", token);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity<LoginResponse> checkLogin(@CookieValue(name = "token", required = false) String token) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalArgumentException("[ERROR] 토큰이 존재하지 않습니다.");
+        }
+
+        String name = jwtUtil.getNameFromToken(token);
+
+        return ResponseEntity.ok(new LoginResponse(name));
+    }
+}

--- a/src/main/java/roomescape/login/LoginMember.java
+++ b/src/main/java/roomescape/login/LoginMember.java
@@ -1,0 +1,4 @@
+package roomescape.login;
+
+public record LoginMember(Long id, String name, String email, String role) {
+}

--- a/src/main/java/roomescape/login/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/login/LoginMemberArgumentResolver.java
@@ -9,7 +9,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -35,16 +34,21 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             throw new IllegalStateException("[ERROR] 요청 정보를 처리하는 중 문제가 발생했습니다.");
         }
 
-        Cookie[] cookies = request.getCookies();
-        String token = Optional.ofNullable(cookies)
-                .flatMap(c -> Arrays.stream(c)
-                        .filter(cookie -> "token".equals(cookie.getName()))
-                        .map(Cookie::getValue)
-                        .findFirst())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 인증 토큰을 찾을 수 없습니다."));
-
+        String token = extractToken(request.getCookies());
         Long memberId = Long.valueOf(jwtUtil.getSubject(token));
 
         return loginService.findLoginMember(memberId);
+    }
+
+    private String extractToken(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new IllegalArgumentException("[ERROR] 인증 토큰을 찾을 수 없습니다.");
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> "token".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 인증 토큰을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/roomescape/login/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/login/LoginMemberArgumentResolver.java
@@ -1,0 +1,55 @@
+package roomescape.login;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import roomescape.member.Member;
+import roomescape.member.MemberDao;
+
+import java.util.Arrays;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+    private final MemberDao memberDao;
+
+    public LoginMemberArgumentResolver(JwtUtil jwtUtil, MemberDao memberDao) {
+        this.jwtUtil = jwtUtil;
+        this.memberDao = memberDao;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request == null) {
+            throw new IllegalStateException("[ERROR] 요청 정보를 처리하는 중 문제가 발생했습니다.");
+        }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new IllegalArgumentException("[ERROR] 로그인 정보가 필요합니다.");
+        }
+
+        String token = Arrays.stream(cookies)
+                .filter(cookie -> "token".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 인증 토큰을 찾을 수 없습니다."));
+
+        Long memberId = Long.valueOf(jwtUtil.getSubject(token));
+        Member member = memberDao.findById(memberId);
+
+        return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+    }
+}

--- a/src/main/java/roomescape/login/LoginRequest.java
+++ b/src/main/java/roomescape/login/LoginRequest.java
@@ -1,0 +1,4 @@
+package roomescape.login;
+
+public record LoginRequest(String email, String password) {
+}

--- a/src/main/java/roomescape/login/LoginResponse.java
+++ b/src/main/java/roomescape/login/LoginResponse.java
@@ -1,0 +1,4 @@
+package roomescape.login;
+
+public record LoginResponse(String name) {
+}

--- a/src/main/java/roomescape/login/LoginService.java
+++ b/src/main/java/roomescape/login/LoginService.java
@@ -16,7 +16,11 @@ public class LoginService {
 
     public String login(String email, String password) {
         Member member = memberDao.findByEmailAndPassword(email, password);
-
         return jwtUtil.createToken(member);
+    }
+
+    public LoginMember findLoginMember(Long id) {
+        Member member = memberDao.findById(id);
+        return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
     }
 }

--- a/src/main/java/roomescape/login/LoginService.java
+++ b/src/main/java/roomescape/login/LoginService.java
@@ -1,0 +1,22 @@
+package roomescape.login;
+
+import org.springframework.stereotype.Service;
+import roomescape.member.Member;
+import roomescape.member.MemberDao;
+
+@Service
+public class LoginService {
+    private final MemberDao memberDao;
+    private final JwtUtil jwtUtil;
+
+    public LoginService(MemberDao memberDao, JwtUtil jwtUtil) {
+        this.memberDao = memberDao;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String login(String email, String password) {
+        Member member = memberDao.findByEmailAndPassword(email, password);
+
+        return jwtUtil.createToken(member);
+    }
+}

--- a/src/main/java/roomescape/login/LoginService.java
+++ b/src/main/java/roomescape/login/LoginService.java
@@ -15,12 +15,14 @@ public class LoginService {
     }
 
     public String login(String email, String password) {
-        Member member = memberDao.findByEmailAndPassword(email, password);
+        Member member = memberDao.findByEmailAndPassword(email, password)
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 이메일 또는 비밀번호가 일치하는 사용자가 없습니다."));
         return jwtUtil.createToken(member);
     }
 
     public LoginMember findLoginMember(Long id) {
-        Member member = memberDao.findById(id);
+        Member member = memberDao.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 해당 ID의 사용자를 찾을 수 없습니다."));
         return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
     }
 }

--- a/src/main/java/roomescape/login/WebConfig.java
+++ b/src/main/java/roomescape/login/WebConfig.java
@@ -1,0 +1,25 @@
+package roomescape.login;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.member.MemberDao;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtUtil jwtUtil;
+    private final MemberDao memberDao;
+
+    public WebConfig(JwtUtil jwtUtil, MemberDao memberDao) {
+        this.jwtUtil = jwtUtil;
+        this.memberDao = memberDao;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(jwtUtil, memberDao));
+    }
+}

--- a/src/main/java/roomescape/login/WebConfig.java
+++ b/src/main/java/roomescape/login/WebConfig.java
@@ -2,6 +2,7 @@ package roomescape.login;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import roomescape.member.MemberDao;
 
@@ -21,5 +22,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginMemberArgumentResolver(jwtUtil, memberDao));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminInterceptor(jwtUtil))
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/roomescape/login/WebConfig.java
+++ b/src/main/java/roomescape/login/WebConfig.java
@@ -12,16 +12,16 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtUtil jwtUtil;
-    private final MemberDao memberDao;
+    private final LoginService loginService;
 
-    public WebConfig(JwtUtil jwtUtil, MemberDao memberDao) {
+    public WebConfig(JwtUtil jwtUtil, LoginService loginService) {
         this.jwtUtil = jwtUtil;
-        this.memberDao = memberDao;
+        this.loginService = loginService;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver(jwtUtil, memberDao));
+        resolvers.add(new LoginMemberArgumentResolver(jwtUtil, loginService));
     }
 
     @Override

--- a/src/main/java/roomescape/member/Member.java
+++ b/src/main/java/roomescape/member/Member.java
@@ -1,24 +1,22 @@
 package roomescape.member;
 
 public class Member {
-    private Long id;
-    private String name;
-    private String email;
-    private String password;
-    private String role;
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final String password;
+    private final String role;
 
-    public Member(Long id, String name, String email, String role) {
+    public Member(Long id, String name, String email, String password, String role) {
         this.id = id;
-        this.name = name;
-        this.email = email;
-        this.role = role;
-    }
-
-    public Member(String name, String email, String password, String role) {
         this.name = name;
         this.email = email;
         this.password = password;
         this.role = role;
+    }
+
+    public Member(String name, String email, String password, String role) {
+        this(null, name, email, password, role);
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -1,6 +1,5 @@
 package roomescape.member;
 
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -8,6 +7,8 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class MemberDao {
@@ -39,42 +40,34 @@ public class MemberDao {
         }, keyHolder);
 
         Long id = keyHolder.getKey().longValue();
-        return findById(id);
+        return findById(id)
+                .orElseThrow(() -> new IllegalStateException("[ERROR] 저장 후 사용자를 찾을 수 없습니다."));
     }
 
-    public Member findByEmailAndPassword(String email, String password) {
-        try {
-            return jdbcTemplate.queryForObject(
-                    "SELECT id, name, email, password, role FROM member WHERE email = ? AND password = ?",
-                    memberRowMapper,
-                    email, password
-            );
-        } catch (EmptyResultDataAccessException e) {
-            throw new IllegalArgumentException("[ERROR] 이메일 또는 비밀번호가 일치하는 사용자가 없습니다.");
-        }
+    public Optional<Member> findByEmailAndPassword(String email, String password) {
+        List<Member> result = jdbcTemplate.query(
+                "SELECT id, name, email, password, role FROM member WHERE email = ? AND password = ?",
+                memberRowMapper,
+                email, password
+        );
+        return result.stream().findAny();
     }
 
-    public Member findByName(String name) {
-        try {
-            return jdbcTemplate.queryForObject(
-                    "SELECT id, name, email, password, role FROM member WHERE name = ?",
-                    memberRowMapper,
-                    name
-            );
-        } catch (EmptyResultDataAccessException e) {
-            throw new IllegalArgumentException("[ERROR] 해당 이름의 사용자를 찾을 수 없습니다.");
-        }
+    public Optional<Member> findByName(String name) {
+        List<Member> result = jdbcTemplate.query(
+                "SELECT id, name, email, password, role FROM member WHERE name = ?",
+                memberRowMapper,
+                name
+        );
+        return result.stream().findAny();
     }
 
-    public Member findById(Long id) {
-        try {
-            return jdbcTemplate.queryForObject(
-                    "SELECT id, name, email, password, role FROM member WHERE id = ?",
-                    memberRowMapper,
-                    id
-            );
-        } catch (EmptyResultDataAccessException e) {
-            throw new IllegalArgumentException("[ERROR] 해당 ID의 사용자를 찾을 수 없습니다.");
-        }
+    public Optional<Member> findById(Long id) {
+        List<Member> result = jdbcTemplate.query(
+                "SELECT id, name, email, password, role FROM member WHERE id = ?",
+                memberRowMapper,
+                id
+        );
+        return result.stream().findAny();
     }
 }

--- a/src/main/java/roomescape/reservation/Reservation.java
+++ b/src/main/java/roomescape/reservation/Reservation.java
@@ -18,17 +18,6 @@ public class Reservation {
         this.theme = theme;
     }
 
-    public Reservation(String name, String date, Time time, Theme theme) {
-        this.name = name;
-        this.date = date;
-        this.time = time;
-        this.theme = theme;
-    }
-
-    public Reservation() {
-
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.login.LoginMember;
 
 import java.net.URI;
 import java.util.List;
@@ -26,21 +27,18 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
-                || reservationRequest.getTheme() == null
-                || reservationRequest.getTime() == null) {
-            return ResponseEntity.badRequest().build();
-        }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+    public ResponseEntity<ReservationResponse> create(
+            @RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
+
+        ReservationResponse reservation = reservationService.create(reservationRequest, loginMember);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }
 
     @DeleteMapping("/reservations/{id}")
-    public ResponseEntity delete(@PathVariable Long id) {
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
         reservationService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
 }
+

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -6,6 +6,13 @@ public class ReservationRequest {
     private Long theme;
     private Long time;
 
+    public ReservationRequest(String name, String date, Long theme, Long time) {
+        this.name = name;
+        this.date = date;
+        this.theme = theme;
+        this.time = time;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,21 +1,40 @@
 package roomescape.reservation;
 
 import org.springframework.stereotype.Service;
+import roomescape.login.LoginMember;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ReservationService {
-    private ReservationDao reservationDao;
+    private final ReservationDao reservationDao;
 
     public ReservationService(ReservationDao reservationDao) {
         this.reservationDao = reservationDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    public ReservationResponse create(ReservationRequest originalRequest, LoginMember loginMember) {
+        String reservationName = Optional.ofNullable(originalRequest.getName())
+                .filter(name -> !name.isBlank())
+                .orElse(loginMember.name());
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        ReservationRequest requestForDao = new ReservationRequest(
+                reservationName,
+                originalRequest.getDate(),
+                originalRequest.getTheme(),
+                originalRequest.getTime()
+        );
+
+        Reservation savedReservation = reservationDao.save(requestForDao);
+
+        return new ReservationResponse(
+                savedReservation.getId(),
+                savedReservation.getName(),
+                savedReservation.getTheme().getName(),
+                savedReservation.getDate(),
+                savedReservation.getTime().getValue()
+        );
     }
 
     public void deleteById(Long id) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+jwt:
+  secret:
+    key: "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E="

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -80,6 +80,25 @@ public class MissionStepTest {
         assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
     }
 
+    @Test
+    void 삼단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        String adminToken = createToken("admin@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
+    }
+
     private String createToken(String email, String password) {
         Map<String, String> params = new HashMap<>();
         params.put("email", email);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -35,4 +36,39 @@ public class MissionStepTest {
 
         assertThat(token).isNotBlank();
     }
+
+    @Test
+    @DisplayName("로그인에 성공하고, 발급된 토큰으로 사용자 정보를 정상적으로 조회한다")
+    void loginAndCheckUserStatus() {
+        // given: 로그인에 필요한 정보를 준비
+        Map<String, String> params = new HashMap<>();
+        params.put("email", "admin@email.com");
+        params.put("password", "password");
+
+        // when: 로그인을 요청
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // then: 응답 쿠키에서 토큰을 성공적으로 추출
+        String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+        assertThat(token).isNotBlank();
+
+        // when: 추출한 토큰으로 사용자 정보 조회를 요청
+        ExtractableResponse<Response> checkResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/login/check")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // then: 조회된 사용자 이름이 예상과 일치
+        assertThat(checkResponse.body().jsonPath().getString("name")).isEqualTo("어드민");
+    }
+
 }


### PR DESCRIPTION
안녕하세요, 오찌!
이번 미션도 잘 부탁드립니다.

이번 미션을 진행하며 고민했던 지점들을 정리해보겠습니다!

1. VO(Value Object) 분리 범위에 대한 질문
- Member 엔티티의 필드 중, 비밀번호(password) 필드만이라도 별도의 VO로 분리할까 고민했습니다. 하지만 현재 요구사항에서는 이러한 설계가 다소 과하다고 판단했는데, 오찌께서는 어떻게 생각하시는지 궁금합니다.

2. 로그인 실패 피드백과 보안의 트레이드오프
- 로그인 실패 시, "아이디가 틀렸습니다" 또는 "비밀번호가 틀렸습니다"와 같이 명확한 정보를 제공하는 것이 UX 측면에서는 더 친절할 수 있다고 생각했습니다. 하지만 보안을 더 중요하게 고려하여, 아이디와 비밀번호 중 어느 하나라도 맞지 않으면 "아이디 또는 비밀번호가 일치하지 않습니다"라는 하나의 통합 메시지를 반환하도록 구현했습니다.구체적인 피드백으로 편의성을 높이기보다, 사용자 경험을 일부 희생하더라도 보안을 강화하는 방향을 선택했는데 이 결정에 대해 어떻게 생각하시나요?