### PR TITLE
[Spring MVC(인증) - 1, 2, 3단계] 이지윤 미션 제출합니다. 

### DIFF
--- a/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
@@ -11,6 +11,7 @@ import roomescape.auth.jwt.JwtTokenProvider;
 
 @Component
 public class AdminAuthorizationInterceptor implements HandlerInterceptor {
+    private static final String ADMIN_ROLE = "ADMIN";
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -27,7 +28,7 @@ public class AdminAuthorizationInterceptor implements HandlerInterceptor {
             Claims claims = jwtTokenProvider.parseClaims(token);
             String role = (String) claims.get("role");
 
-            if (!"ADMIN".equals(role)) {
+            if (!ADMIN_ROLE.equals(role)) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return false;
             }

--- a/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
@@ -1,5 +1,7 @@
 package roomescape.auth;
 
+import static roomescape.member.Role.ADMIN;
+
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,8 +13,6 @@ import roomescape.auth.jwt.JwtTokenProvider;
 
 @Component
 public class AdminAuthorizationInterceptor implements HandlerInterceptor {
-    private static final String ADMIN_ROLE = "ADMIN";
-
     private final JwtTokenProvider jwtTokenProvider;
 
     public AdminAuthorizationInterceptor(JwtTokenProvider jwtTokenProvider) {
@@ -28,7 +28,7 @@ public class AdminAuthorizationInterceptor implements HandlerInterceptor {
             Claims claims = jwtTokenProvider.parseClaims(token);
             String role = (String) claims.get("role");
 
-            if (!ADMIN_ROLE.equals(role)) {
+            if (!ADMIN.name().equals(role)) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return false;
             }

--- a/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminAuthorizationInterceptor.java
@@ -1,0 +1,41 @@
+package roomescape.auth;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import roomescape.auth.jwt.JwtTokenExtractor;
+import roomescape.auth.jwt.JwtTokenProvider;
+
+@Component
+public class AdminAuthorizationInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AdminAuthorizationInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(@NotNull HttpServletRequest request,
+                             @NotNull HttpServletResponse response,
+                             @NotNull Object handler) {
+        try {
+            String token = JwtTokenExtractor.extract(request);
+            Claims claims = jwtTokenProvider.parseClaims(token);
+            String role = (String) claims.get("role");
+
+            if (!"ADMIN".equals(role)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
+            }
+            return true;
+
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+    }
+}

--- a/src/main/java/roomescape/auth/AuthController.java
+++ b/src/main/java/roomescape/auth/AuthController.java
@@ -7,14 +7,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.auth.jwt.JwtCookieProvider;
 import roomescape.member.Member;
 import roomescape.member.MemberResponse;
 
 @RestController
 @RequestMapping("/login")
 public class AuthController {
-    private static final String TOKEN_COOKIE_NAME = "token";
-
     private final AuthService authService;
 
     public AuthController(AuthService authService) {
@@ -24,10 +23,7 @@ public class AuthController {
     @PostMapping
     public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
         String token = authService.createToken(loginRequest);
-        ResponseCookie cookie = ResponseCookie.from(TOKEN_COOKIE_NAME, token)
-                .httpOnly(true)
-                .path("/")
-                .build();
+        ResponseCookie cookie = JwtCookieProvider.loginCookie(token);
         return ResponseEntity.ok()
                 .header("Set-Cookie", cookie.toString())
                 .build();

--- a/src/main/java/roomescape/auth/AuthController.java
+++ b/src/main/java/roomescape/auth/AuthController.java
@@ -1,0 +1,54 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.member.Member;
+import roomescape.member.MemberResponse;
+
+@RestController
+@RequestMapping("/login")
+public class AuthController {
+    private static final String TOKEN_COOKIE_NAME = "token";
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
+        String token = authService.createToken(loginRequest);
+        ResponseCookie cookie = ResponseCookie.from(TOKEN_COOKIE_NAME, token)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        return ResponseEntity.ok()
+                .header("Set-Cookie", cookie.toString())
+                .build();
+    }
+
+    @GetMapping("/check")
+    public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String token = extractTokenFromCookie(cookies);
+        Member member = authService.findMemberByToken(token);
+        return ResponseEntity.ok(new MemberResponse(member.getId(), member.getName(), member.getEmail()));
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(TOKEN_COOKIE_NAME)) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/roomescape/auth/AuthController.java
+++ b/src/main/java/roomescape/auth/AuthController.java
@@ -1,7 +1,5 @@
 package roomescape.auth;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/roomescape/auth/AuthController.java
+++ b/src/main/java/roomescape/auth/AuthController.java
@@ -36,19 +36,7 @@ public class AuthController {
     }
 
     @GetMapping("/check")
-    public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        String token = extractTokenFromCookie(cookies);
-        Member member = authService.findMemberByToken(token);
+    public ResponseEntity<MemberResponse> checkLogin(@Login Member member) {
         return ResponseEntity.ok(new MemberResponse(member.getId(), member.getName(), member.getEmail()));
-    }
-
-    private String extractTokenFromCookie(Cookie[] cookies) {
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals(TOKEN_COOKIE_NAME)) {
-                return cookie.getValue();
-            }
-        }
-        return "";
     }
 }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
         return memberService.findById(memberId);
     }
 
-    private void validateExpireToken(final String token) {
+    private void validateExpireToken(String token) {
         if (!tokenProvider.validateToken(token)) {
             throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
         }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -3,17 +3,19 @@ package roomescape.auth;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.auth.jwt.JwtTokenExtractor;
+import roomescape.auth.jwt.JwtTokenProvider;
 import roomescape.member.Member;
-import roomescape.member.MemberDao;
+import roomescape.member.MemberService;
 
 @Service
 public class AuthService {
     private final JwtTokenProvider tokenProvider;
-    private final MemberDao memberDao;
+    private final MemberService memberService;
 
-    public AuthService(JwtTokenProvider tokenProvider, MemberDao memberDao) {
+    public AuthService(JwtTokenProvider tokenProvider, MemberService memberService) {
         this.tokenProvider = tokenProvider;
-        this.memberDao = memberDao;
+        this.memberService = memberService;
     }
 
     @Transactional
@@ -23,20 +25,18 @@ public class AuthService {
     }
 
     private Member findMember(LoginRequest loginRequest) {
-        return memberDao.findByEmailAndPassword(loginRequest.email(), loginRequest.password())
-                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
+        return memberService.findByEmailAndPassword(loginRequest.email(), loginRequest.password());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Member findMemberByToken(HttpServletRequest request) {
-        String token = tokenProvider.resolveToken(request);
-        validateTokenExpire(token);
+        String token = JwtTokenExtractor.extract(request);
+        validateExpireToken(token);
         Long memberId = tokenProvider.extractIdFromToken(token);
-        return memberDao.findById(memberId)
-                .orElseThrow(() -> new IllegalStateException("토큰의 사용자 정보가 유효하지 않습니다."));
+        return memberService.findById(memberId);
     }
 
-    private void validateTokenExpire(String token) {
+    private void validateExpireToken(final String token) {
         if (!tokenProvider.validateToken(token)) {
             throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
         }

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -1,0 +1,42 @@
+package roomescape.auth;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.member.Member;
+import roomescape.member.MemberDao;
+
+@Service
+public class AuthService {
+    private final JwtTokenProvider tokenProvider;
+    private final MemberDao memberDao;
+
+    public AuthService(JwtTokenProvider tokenProvider, MemberDao memberDao) {
+        this.tokenProvider = tokenProvider;
+        this.memberDao = memberDao;
+    }
+
+    @Transactional
+    public String createToken(LoginRequest loginRequest) {
+        Member member = findMember(loginRequest);
+        return tokenProvider.generateToken(member.getId(), member.getName(), member.getRole());
+    }
+
+    private Member findMember(LoginRequest loginRequest) {
+        return memberDao.findByEmailAndPassword(loginRequest.email(), loginRequest.password())
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
+    }
+
+    @Transactional
+    public Member findMemberByToken(String token) {
+        validateTokenExpire(token);
+        Long memberId = tokenProvider.extractIdFromToken(token);
+        return memberDao.findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("토큰의 사용자 정보가 유효하지 않습니다."));
+    }
+
+    private void validateTokenExpire(String token) {
+        if (!tokenProvider.validateToken(token)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/roomescape/auth/AuthService.java
+++ b/src/main/java/roomescape/auth/AuthService.java
@@ -1,5 +1,6 @@
 package roomescape.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.member.Member;
@@ -27,7 +28,8 @@ public class AuthService {
     }
 
     @Transactional
-    public Member findMemberByToken(String token) {
+    public Member findMemberByToken(HttpServletRequest request) {
+        String token = tokenProvider.resolveToken(request);
         validateTokenExpire(token);
         Long memberId = tokenProvider.extractIdFromToken(token);
         return memberDao.findById(memberId)

--- a/src/main/java/roomescape/auth/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/JwtTokenProvider.java
@@ -1,0 +1,53 @@
+package roomescape.auth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+    private static final String NAME_KEY = "name";
+    private static final String ROLE_KEY = "role";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    @Value("${roomescape.auth.jwt.secret}")
+    private String secretKey;
+
+    @Value("${roomescape.auth.jwt.token.expire-length}")
+    private long validityInMilliseconds;
+
+    public String generateToken(Long id, String name, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(String.valueOf(id))
+                .claim(NAME_KEY, name)
+                .claim(ROLE_KEY, ROLE_PREFIX + role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + validityInMilliseconds))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long extractIdFromToken(String token) {
+        validateToken(token);
+        return Long.valueOf(Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody().getSubject());
+    }
+}

--- a/src/main/java/roomescape/auth/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package roomescape.auth;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -49,5 +51,18 @@ public class JwtTokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody().getSubject());
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("token")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/roomescape/auth/Login.java
+++ b/src/main/java/roomescape/auth/Login.java
@@ -1,0 +1,11 @@
+package roomescape.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,34 @@
+package roomescape.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthService authService;
+
+    public LoginMemberArgumentResolver(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Login.class);
+    }
+
+    @Override
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request == null) {
+            throw new IllegalStateException("요청 객체를 얻지 못했습니다.");
+        }
+        return authService.findMemberByToken(request);
+    }
+}

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -23,8 +23,10 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     @Override
-    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(@NotNull MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         if (request == null) {
             throw new IllegalStateException("요청 객체를 얻지 못했습니다.");

--- a/src/main/java/roomescape/auth/LoginRequest.java
+++ b/src/main/java/roomescape/auth/LoginRequest.java
@@ -1,0 +1,7 @@
+package roomescape.auth;
+
+public record LoginRequest(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/roomescape/auth/jwt/JwtCookieProvider.java
+++ b/src/main/java/roomescape/auth/jwt/JwtCookieProvider.java
@@ -1,0 +1,25 @@
+package roomescape.auth.jwt;
+
+import org.springframework.http.ResponseCookie;
+
+public final class JwtCookieProvider {
+    static final String TOKEN_COOKIE_NAME = "token";
+
+    private JwtCookieProvider() {
+    }
+
+    public static ResponseCookie loginCookie(String token) {
+        return ResponseCookie.from(TOKEN_COOKIE_NAME, token)
+                .httpOnly(true)
+                .path("/")
+                .build();
+    }
+
+    public static ResponseCookie logoutCookie() {
+        return ResponseCookie.from(TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+}

--- a/src/main/java/roomescape/auth/jwt/JwtTokenExtractor.java
+++ b/src/main/java/roomescape/auth/jwt/JwtTokenExtractor.java
@@ -1,0 +1,26 @@
+package roomescape.auth.jwt;
+
+import static roomescape.auth.jwt.JwtCookieProvider.TOKEN_COOKIE_NAME;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class JwtTokenExtractor {
+
+    private JwtTokenExtractor() {
+    }
+
+    public static String extract(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/roomescape/auth/jwt/JwtTokenExtractor.java
+++ b/src/main/java/roomescape/auth/jwt/JwtTokenExtractor.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 public final class JwtTokenExtractor {
-
     private JwtTokenExtractor() {
     }
 

--- a/src/main/java/roomescape/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/roomescape/auth/jwt/JwtTokenProvider.java
@@ -1,9 +1,8 @@
-package roomescape.auth;
+package roomescape.auth.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
     private static final String NAME_KEY = "name";
     private static final String ROLE_KEY = "role";
-    private static final String ROLE_PREFIX = "ROLE_";
 
     @Value("${roomescape.auth.jwt.secret}")
     private String secretKey;
@@ -25,11 +23,15 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setSubject(String.valueOf(id))
                 .claim(NAME_KEY, name)
-                .claim(ROLE_KEY, ROLE_PREFIX + role)
+                .claim(ROLE_KEY, role)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + validityInMilliseconds))
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
+    }
+
+    public Long extractIdFromToken(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
     }
 
     public boolean validateToken(String token) {
@@ -44,25 +46,11 @@ public class JwtTokenProvider {
         }
     }
 
-    public Long extractIdFromToken(String token) {
-        validateToken(token);
-        return Long.valueOf(Jwts.parserBuilder()
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
                 .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .build()
                 .parseClaimsJws(token)
-                .getBody().getSubject());
-    }
-
-    public String resolveToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return null;
-        }
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("token")) {
-                return cookie.getValue();
-            }
-        }
-        return null;
+                .getBody();
     }
 }

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -1,17 +1,16 @@
 package roomescape.config;
 
+import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import roomescape.auth.LoginMemberArgumentResolver;
 
-import java.util.List;
-
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
-    public WebConfig(final LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
     }
 

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -1,0 +1,22 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.auth.LoginMemberArgumentResolver;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(final LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -3,19 +3,30 @@ package roomescape.config;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.auth.AdminAuthorizationInterceptor;
 import roomescape.auth.LoginMemberArgumentResolver;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final AdminAuthorizationInterceptor adminAuthorizationInterceptor;
 
-    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver,
+                     AdminAuthorizationInterceptor adminAuthorizationInterceptor) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.adminAuthorizationInterceptor = adminAuthorizationInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminAuthorizationInterceptor)
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/roomescape/member/Member.java
+++ b/src/main/java/roomescape/member/Member.java
@@ -5,16 +5,16 @@ public class Member {
     private String name;
     private String email;
     private String password;
-    private String role;
+    private Role role;
 
-    public Member(Long id, String name, String email, String role) {
+    public Member(Long id, String name, String email, Role role) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.role = role;
     }
 
-    public Member(String name, String email, String password, String role) {
+    public Member(String name, String email, String password, Role role) {
         this.name = name;
         this.email = email;
         this.password = password;
@@ -38,6 +38,6 @@ public class Member {
     }
 
     public String getRole() {
-        return role;
+        return role.name();
     }
 }

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -17,13 +17,13 @@ public class MemberController {
     }
 
     @PostMapping("/members")
-    public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
-        MemberResponse member = memberService.createMember(memberRequest);
+    public ResponseEntity<MemberResponse> createMember(@RequestBody MemberRequest memberRequest) {
+        MemberResponse member = memberService.create(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + member.id())).body(member);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity logout(HttpServletResponse response) {
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("token", "");
         cookie.setHttpOnly(true);
         cookie.setPath("/");

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -1,19 +1,16 @@
 package roomescape.member;
 
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-
 @RestController
 public class MemberController {
-    private MemberService memberService;
+    private final MemberService memberService;
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -1,12 +1,12 @@
 package roomescape.member;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.auth.jwt.JwtCookieProvider;
 
 @RestController
 public class MemberController {
@@ -23,12 +23,10 @@ public class MemberController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
-        Cookie cookie = new Cookie("token", "");
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> logout() {
+        ResponseCookie deleteCookie = JwtCookieProvider.logoutCookie();
+        return ResponseEntity.ok()
+                .header("Set-Cookie", deleteCookie.toString())
+                .build();
     }
 }

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController {
     @PostMapping("/members")
     public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
         MemberResponse member = memberService.createMember(memberRequest);
-        return ResponseEntity.created(URI.create("/members/" + member.getId())).body(member);
+        return ResponseEntity.created(URI.create("/members/" + member.id())).body(member);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -1,5 +1,7 @@
 package roomescape.member;
 
+import java.sql.PreparedStatement;
+import java.util.Optional;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
@@ -7,7 +9,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class MemberDao {
-    private JdbcTemplate jdbcTemplate;
+    private static final String DEFAULT_ROLE = "USER";
+
+    private final JdbcTemplate jdbcTemplate;
 
     public MemberDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -16,7 +20,9 @@ public class MemberDao {
     public Member save(Member member) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
-            var ps = connection.prepareStatement("INSERT INTO member(name, email, password, role) VALUES (?, ?, ?, ?)", new String[]{"id"});
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO member(name, email, password, role) VALUES (?, ?, ?, ?)",
+                    new String[]{"id"});
             ps.setString(1, member.getName());
             ps.setString(2, member.getEmail());
             ps.setString(3, member.getPassword());
@@ -24,32 +30,40 @@ public class MemberDao {
             return ps;
         }, keyHolder);
 
-        return new Member(keyHolder.getKey().longValue(), member.getName(), member.getEmail(), "USER");
+        return new Member(keyHolder.getKey().longValue(), member.getName(), member.getEmail(), DEFAULT_ROLE);
     }
 
-    public Member findByEmailAndPassword(String email, String password) {
-        return jdbcTemplate.queryForObject(
-                "SELECT id, name, email, role FROM member WHERE email = ? AND password = ?",
-                (rs, rowNum) -> new Member(
-                        rs.getLong("id"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("role")
-                ),
-                email, password
-        );
+    public Optional<Member> findByEmailAndPassword(String email, String password) {
+        try {
+            Member member = jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE email = ? AND password = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ),
+                    email, password);
+            return Optional.ofNullable(member);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 
-    public Member findByName(String name) {
-        return jdbcTemplate.queryForObject(
-                "SELECT id, name, email, role FROM member WHERE name = ?",
-                (rs, rowNum) -> new Member(
-                        rs.getLong("id"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("role")
-                ),
-                name
-        );
+    public Optional<Member> findById(Long id) {
+        try {
+            Member member = jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE id = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ), id
+            );
+            return Optional.ofNullable(member);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -66,4 +66,21 @@ public class MemberDao {
             return Optional.empty();
         }
     }
+
+    public Optional<Member> findByName(String name) {
+        try {
+            Member member = jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE name = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ), name
+            );
+            return Optional.ofNullable(member);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -1,5 +1,7 @@
 package roomescape.member;
 
+import static roomescape.member.Role.USER;
+
 import java.sql.PreparedStatement;
 import java.util.Optional;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -9,8 +11,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class MemberDao {
-    private static final String DEFAULT_ROLE = "USER";
-
     private final JdbcTemplate jdbcTemplate;
 
     public MemberDao(JdbcTemplate jdbcTemplate) {
@@ -30,7 +30,7 @@ public class MemberDao {
             return ps;
         }, keyHolder);
 
-        return new Member(keyHolder.getKey().longValue(), member.getName(), member.getEmail(), DEFAULT_ROLE);
+        return new Member(keyHolder.getKey().longValue(), member.getName(), member.getEmail(), USER);
     }
 
     public Optional<Member> findByEmailAndPassword(String email, String password) {
@@ -41,7 +41,7 @@ public class MemberDao {
                             rs.getLong("id"),
                             rs.getString("name"),
                             rs.getString("email"),
-                            rs.getString("role")
+                            Role.valueOf(rs.getString("role"))
                     ),
                     email, password);
             return Optional.ofNullable(member);
@@ -58,7 +58,7 @@ public class MemberDao {
                             rs.getLong("id"),
                             rs.getString("name"),
                             rs.getString("email"),
-                            rs.getString("role")
+                            Role.valueOf(rs.getString("role"))
                     ), id
             );
             return Optional.ofNullable(member);
@@ -75,7 +75,7 @@ public class MemberDao {
                             rs.getLong("id"),
                             rs.getString("name"),
                             rs.getString("email"),
-                            rs.getString("role")
+                            Role.valueOf(rs.getString("role"))
                     ), name
             );
             return Optional.ofNullable(member);

--- a/src/main/java/roomescape/member/MemberRequest.java
+++ b/src/main/java/roomescape/member/MemberRequest.java
@@ -1,19 +1,8 @@
 package roomescape.member;
 
-public class MemberRequest {
-    private String name;
-    private String email;
-    private String password;
-
-    public String getName() {
-        return name;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
+public record MemberRequest(
+        String name,
+        String email,
+        String password
+) {
 }

--- a/src/main/java/roomescape/member/MemberResponse.java
+++ b/src/main/java/roomescape/member/MemberResponse.java
@@ -1,25 +1,8 @@
 package roomescape.member;
 
-public class MemberResponse {
-    private Long id;
-    private String name;
-    private String email;
-
-    public MemberResponse(Long id, String name, String email) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getEmail() {
-        return email;
-    }
+public record MemberResponse(
+        Long id,
+        String name,
+        String email
+) {
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,6 +1,5 @@
 package roomescape.member;
 
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +20,21 @@ public class MemberService {
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
 
-    @Transactional
-    public Optional<Member> findByName(String name) {
-        return memberDao.findByName(name);
+    @Transactional(readOnly = true)
+    public Member findByEmailAndPassword(String email, String password) {
+        return memberDao.findByEmailAndPassword(email, password)
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Member findById(Long id) {
+        return memberDao.findById(id)
+                .orElseThrow(() -> new IllegalStateException("토큰의 사용자 정보가 유효하지 않습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Member findByName(String name) {
+        return memberDao.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MemberService {
-    private static final String ROLE = "USER";
+    private static final String DEFAULT_ROLE = "USER";
 
     private final MemberDao memberDao;
 
@@ -14,7 +14,7 @@ public class MemberService {
 
     public MemberResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(
-                new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), ROLE));
+                new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), DEFAULT_ROLE));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -4,14 +4,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MemberService {
-    private MemberDao memberDao;
+    private static final String ROLE = "USER";
+
+    private final MemberDao memberDao;
 
     public MemberService(MemberDao memberDao) {
         this.memberDao = memberDao;
     }
 
     public MemberResponse createMember(MemberRequest memberRequest) {
-        Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
+        Member member = memberDao.save(
+                new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), ROLE));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,6 +1,8 @@
 package roomescape.member;
 
+import java.util.Optional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
@@ -12,9 +14,15 @@ public class MemberService {
         this.memberDao = memberDao;
     }
 
-    public MemberResponse createMember(MemberRequest memberRequest) {
+    @Transactional
+    public MemberResponse create(MemberRequest memberRequest) {
         Member member = memberDao.save(
                 new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), DEFAULT_ROLE));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+    }
+
+    @Transactional
+    public Optional<Member> findByName(String name) {
+        return memberDao.findByName(name);
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,12 +1,12 @@
 package roomescape.member;
 
+import static roomescape.member.Role.USER;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
-    private static final String DEFAULT_ROLE = "USER";
-
     private final MemberDao memberDao;
 
     public MemberService(MemberDao memberDao) {
@@ -16,7 +16,7 @@ public class MemberService {
     @Transactional
     public MemberResponse create(MemberRequest memberRequest) {
         Member member = memberDao.save(
-                new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), DEFAULT_ROLE));
+                new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), USER));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
 

--- a/src/main/java/roomescape/member/Role.java
+++ b/src/main/java/roomescape/member/Role.java
@@ -1,0 +1,5 @@
+package roomescape.member;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/roomescape/reservation/Reservation.java
+++ b/src/main/java/roomescape/reservation/Reservation.java
@@ -25,10 +25,6 @@ public class Reservation {
         this.theme = theme;
     }
 
-    public Reservation() {
-
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.auth.Login;
+import roomescape.member.Member;
 
 @RestController
 @RequestMapping("/reservations")
@@ -21,25 +23,20 @@ public class ReservationController {
     }
 
     @GetMapping
-    public List<ReservationResponse> list() {
+    public List<ReservationResponse> getAllReservation() {
         return reservationService.findAll();
     }
 
     @PostMapping
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.name() == null
-                || reservationRequest.date() == null
-                || reservationRequest.time() == null
-                || reservationRequest.theme() == null) {
-            return ResponseEntity.badRequest().build();
-        }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
-
-        return ResponseEntity.created(URI.create("/reservations/" + reservation.id())).body(reservation);
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest reservationRequest,
+                                                                 @Login Member loginMember) {
+        ReservationResponse reservation = reservationService.save(reservationRequest, loginMember);
+        return ResponseEntity.created(URI.create("/reservations/" + reservation.id()))
+                .body(reservation);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity delete(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
         reservationService.deleteById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -1,31 +1,31 @@
 package roomescape.reservation;
 
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.util.List;
-
 @RestController
+@RequestMapping("/reservations")
 public class ReservationController {
-
     private final ReservationService reservationService;
 
     public ReservationController(ReservationService reservationService) {
         this.reservationService = reservationService;
     }
 
-    @GetMapping("/reservations")
+    @GetMapping
     public List<ReservationResponse> list() {
         return reservationService.findAll();
     }
 
-    @PostMapping("/reservations")
+    @PostMapping
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
         if (reservationRequest.getName() == null
                 || reservationRequest.getDate() == null
@@ -38,7 +38,7 @@ public class ReservationController {
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }
 
-    @DeleteMapping("/reservations/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity delete(@PathVariable Long id) {
         reservationService.deleteById(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -27,15 +27,15 @@ public class ReservationController {
 
     @PostMapping
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
-                || reservationRequest.getTheme() == null
-                || reservationRequest.getTime() == null) {
+        if (reservationRequest.name() == null
+                || reservationRequest.date() == null
+                || reservationRequest.time() == null
+                || reservationRequest.theme() == null) {
             return ResponseEntity.badRequest().build();
         }
         ReservationResponse reservation = reservationService.save(reservationRequest);
 
-        return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
+        return ResponseEntity.created(URI.create("/reservations/" + reservation.id())).body(reservation);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/roomescape/reservation/ReservationDao.java
@@ -17,6 +17,27 @@ public class ReservationDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    public Reservation save(Reservation reservation) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
+            ps.setString(1, reservation.getDate());
+            ps.setString(2, reservation.getName());
+            ps.setLong(3, reservation.getTheme().getId());
+            ps.setLong(4, reservation.getTime().getId());
+            return ps;
+        }, keyHolder);
+
+        return new Reservation(
+                keyHolder.getKey().longValue(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime(),
+                reservation.getTheme()
+        );
+    }
+
     public List<Reservation> findAll() {
         return jdbcTemplate.query(
                 "SELECT r.id AS reservation_id, r.name as reservation_name, r.date as reservation_date, " +
@@ -39,39 +60,6 @@ public class ReservationDao {
                                 rs.getString("theme_name"),
                                 rs.getString("theme_description")
                         )));
-    }
-
-    public Reservation save(ReservationRequest reservationRequest) {
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(
-                    "INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
-            ps.setString(1, reservationRequest.date());
-            ps.setString(2, reservationRequest.name());
-            ps.setLong(3, reservationRequest.theme());
-            ps.setLong(4, reservationRequest.theme());
-            return ps;
-        }, keyHolder);
-
-        Time time = jdbcTemplate.queryForObject("SELECT * FROM time WHERE id = ?",
-                (rs, rowNum) -> new Time(rs.getLong("id"), rs.getString("time_value")),
-                reservationRequest.time());
-
-        Theme theme = jdbcTemplate.queryForObject("SELECT * FROM theme WHERE id = ?",
-                (rs, rowNum) -> new Theme(rs.getLong("id"), rs.getString("name"), rs.getString("description")),
-                reservationRequest.theme());
-
-        return new Reservation(
-                keyHolder.getKey().longValue(),
-                reservationRequest.name(),
-                reservationRequest.date(),
-                time,
-                theme
-        );
-    }
-
-    public void deleteById(Long id) {
-        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
     }
 
     public List<Reservation> findReservationsByDateAndTheme(String date, Long themeId) {
@@ -122,5 +110,9 @@ public class ReservationDao {
                                 rs.getString("theme_name"),
                                 rs.getString("theme_description")
                         )));
+    }
+
+    public void deleteById(Long id) {
+        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/roomescape/reservation/ReservationDao.java
@@ -46,25 +46,25 @@ public class ReservationDao {
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement(
                     "INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
-            ps.setString(1, reservationRequest.getDate());
-            ps.setString(2, reservationRequest.getName());
-            ps.setLong(3, reservationRequest.getTheme());
-            ps.setLong(4, reservationRequest.getTime());
+            ps.setString(1, reservationRequest.date());
+            ps.setString(2, reservationRequest.name());
+            ps.setLong(3, reservationRequest.theme());
+            ps.setLong(4, reservationRequest.theme());
             return ps;
         }, keyHolder);
 
         Time time = jdbcTemplate.queryForObject("SELECT * FROM time WHERE id = ?",
                 (rs, rowNum) -> new Time(rs.getLong("id"), rs.getString("time_value")),
-                reservationRequest.getTime());
+                reservationRequest.time());
 
         Theme theme = jdbcTemplate.queryForObject("SELECT * FROM theme WHERE id = ?",
                 (rs, rowNum) -> new Theme(rs.getLong("id"), rs.getString("name"), rs.getString("description")),
-                reservationRequest.getTheme());
+                reservationRequest.theme());
 
         return new Reservation(
                 keyHolder.getKey().longValue(),
-                reservationRequest.getName(),
-                reservationRequest.getDate(),
+                reservationRequest.name(),
+                reservationRequest.date(),
                 time,
                 theme
         );

--- a/src/main/java/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/roomescape/reservation/ReservationDao.java
@@ -1,5 +1,7 @@
 package roomescape.reservation;
 
+import java.sql.PreparedStatement;
+import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
@@ -7,12 +9,8 @@ import org.springframework.stereotype.Repository;
 import roomescape.theme.Theme;
 import roomescape.time.Time;
 
-import java.sql.PreparedStatement;
-import java.util.List;
-
 @Repository
 public class ReservationDao {
-
     private final JdbcTemplate jdbcTemplate;
 
     public ReservationDao(JdbcTemplate jdbcTemplate) {
@@ -46,7 +44,8 @@ public class ReservationDao {
     public Reservation save(ReservationRequest reservationRequest) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement("INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
             ps.setString(1, reservationRequest.getDate());
             ps.setString(2, reservationRequest.getName());
             ps.setLong(3, reservationRequest.getTheme());

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -1,24 +1,9 @@
 package roomescape.reservation;
 
-public class ReservationRequest {
-    private String name;
-    private String date;
-    private Long theme;
-    private Long time;
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public Long getTheme() {
-        return theme;
-    }
-
-    public Long getTime() {
-        return time;
-    }
+public record ReservationRequest(
+        String name,
+        String date,
+        Long time,
+        Long theme
+) {
 }

--- a/src/main/java/roomescape/reservation/ReservationResponse.java
+++ b/src/main/java/roomescape/reservation/ReservationResponse.java
@@ -1,37 +1,10 @@
 package roomescape.reservation;
 
-public class ReservationResponse {
-    private Long id;
-    private String name;
-    private String theme;
-    private String date;
-    private String time;
-
-    public ReservationResponse(Long id, String name, String theme, String date, String time) {
-        this.id = id;
-        this.name = name;
-        this.theme = theme;
-        this.date = date;
-        this.time = time;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getTheme() {
-        return theme;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public String getTime() {
-        return time;
-    }
+public record ReservationResponse(
+        Long id,
+        String name,
+        String theme,
+        String date,
+        String time
+) {
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,12 +1,11 @@
 package roomescape.reservation;
 
-import org.springframework.stereotype.Service;
-
 import java.util.List;
+import org.springframework.stereotype.Service;
 
 @Service
 public class ReservationService {
-    private ReservationDao reservationDao;
+    private final ReservationDao reservationDao;
 
     public ReservationService(ReservationDao reservationDao) {
         this.reservationDao = reservationDao;
@@ -15,7 +14,8 @@ public class ReservationService {
     public ReservationResponse save(ReservationRequest reservationRequest) {
         Reservation reservation = reservationDao.save(reservationRequest);
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        return new ReservationResponse(reservation.getId(), reservationRequest.getName(),
+                reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
     }
 
     public void deleteById(Long id) {
@@ -24,7 +24,8 @@ public class ReservationService {
 
     public List<ReservationResponse> findAll() {
         return reservationDao.findAll().stream()
-                .map(it -> new ReservationResponse(it.getId(), it.getName(), it.getTheme().getName(), it.getDate(), it.getTime().getValue()))
+                .map(it -> new ReservationResponse(it.getId(), it.getName(), it.getTheme().getName(), it.getDate(),
+                        it.getTime().getValue()))
                 .toList();
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -14,7 +14,7 @@ public class ReservationService {
     public ReservationResponse save(ReservationRequest reservationRequest) {
         Reservation reservation = reservationDao.save(reservationRequest);
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(),
+        return new ReservationResponse(reservation.getId(), reservationRequest.name(),
                 reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
     }
 

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -2,30 +2,65 @@ package roomescape.reservation;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.member.Member;
+import roomescape.member.MemberService;
+import roomescape.theme.Theme;
+import roomescape.theme.ThemeDao;
+import roomescape.time.Time;
+import roomescape.time.TimeDao;
 
 @Service
 public class ReservationService {
     private final ReservationDao reservationDao;
+    private final MemberService memberService;
+    private final TimeDao timeDao;
+    private final ThemeDao themeDao;
 
-    public ReservationService(ReservationDao reservationDao) {
+    public ReservationService(ReservationDao reservationDao, MemberService memberService, TimeDao timeDao,
+                              ThemeDao themeDao) {
         this.reservationDao = reservationDao;
+        this.memberService = memberService;
+        this.timeDao = timeDao;
+        this.themeDao = themeDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    @Transactional
+    public ReservationResponse save(ReservationRequest reservationRequest, Member loginMember) {
+        Member member = getMemberFromRequest(reservationRequest, loginMember);
+        Time time = timeDao.findById(reservationRequest.time());
+        Theme theme = themeDao.findById(reservationRequest.theme());
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.name(),
-                reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        Reservation reservation = new Reservation(member.getName(), reservationRequest.date(), time, theme);
+        Reservation savedReservation = reservationDao.save(reservation);
+
+        return new ReservationResponse(
+                savedReservation.getId(),
+                savedReservation.getName(),
+                savedReservation.getTheme().getName(),
+                savedReservation.getDate(),
+                savedReservation.getTime().getValue()
+        );
     }
 
-    public void deleteById(Long id) {
-        reservationDao.deleteById(id);
+    private Member getMemberFromRequest(ReservationRequest reservationRequest, Member loginMember) {
+        if (reservationRequest.name() != null) {
+            return memberService.findByName(reservationRequest.name())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        }
+        return loginMember;
     }
 
+    @Transactional(readOnly = true)
     public List<ReservationResponse> findAll() {
         return reservationDao.findAll().stream()
                 .map(it -> new ReservationResponse(it.getId(), it.getName(), it.getTheme().getName(), it.getDate(),
                         it.getTime().getValue()))
                 .toList();
+    }
+
+    @Transactional
+    public void deleteById(Long id) {
+        reservationDao.deleteById(id);
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -45,8 +45,7 @@ public class ReservationService {
 
     private Member getMemberFromRequest(ReservationRequest reservationRequest, Member loginMember) {
         if (reservationRequest.name() != null) {
-            return memberService.findByName(reservationRequest.name())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+            return memberService.findByName(reservationRequest.name());
         }
         return loginMember;
     }

--- a/src/main/java/roomescape/theme/Theme.java
+++ b/src/main/java/roomescape/theme/Theme.java
@@ -5,9 +5,6 @@ public class Theme {
     private String name;
     private String description;
 
-    public Theme() {
-    }
-
     public Theme(Long id, String name, String description) {
         this.id = id;
         this.name = name;

--- a/src/main/java/roomescape/theme/ThemeController.java
+++ b/src/main/java/roomescape/theme/ThemeController.java
@@ -1,36 +1,37 @@
 package roomescape.theme;
 
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.util.List;
-
 @RestController
+@RequestMapping("/themes")
 public class ThemeController {
-    private ThemeDao themeDao;
+    private final ThemeDao themeDao;
 
     public ThemeController(ThemeDao themeDao) {
         this.themeDao = themeDao;
     }
 
-    @PostMapping("/themes")
+    @PostMapping
     public ResponseEntity<Theme> createTheme(@RequestBody Theme theme) {
         Theme newTheme = themeDao.save(theme);
         return ResponseEntity.created(URI.create("/themes/" + newTheme.getId())).body(newTheme);
     }
 
-    @GetMapping("/themes")
+    @GetMapping
     public ResponseEntity<List<Theme>> list() {
         return ResponseEntity.ok(themeDao.findAll());
     }
 
-    @DeleteMapping("/themes/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTheme(@PathVariable Long id) {
         themeDao.deleteById(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/roomescape/theme/ThemeController.java
+++ b/src/main/java/roomescape/theme/ThemeController.java
@@ -27,7 +27,7 @@ public class ThemeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Theme>> list() {
+    public ResponseEntity<List<Theme>> getAllTheme() {
         return ResponseEntity.ok(themeDao.findAll());
     }
 

--- a/src/main/java/roomescape/theme/ThemeDao.java
+++ b/src/main/java/roomescape/theme/ThemeDao.java
@@ -15,14 +15,6 @@ public class ThemeDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public List<Theme> findAll() {
-        return jdbcTemplate.query("SELECT * FROM theme where deleted = false", (rs, rowNum) -> new Theme(
-                rs.getLong("id"),
-                rs.getString("name"),
-                rs.getString("description")
-        ));
-    }
-
     public Theme save(Theme theme) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
@@ -34,6 +26,23 @@ public class ThemeDao {
         }, keyHolder);
 
         return new Theme(keyHolder.getKey().longValue(), theme.getName(), theme.getDescription());
+    }
+
+    public List<Theme> findAll() {
+        return jdbcTemplate.query("SELECT * FROM theme where deleted = false", (rs, rowNum) -> new Theme(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("description")
+        ));
+    }
+
+    public Theme findById(Long id) {
+        return jdbcTemplate.queryForObject("SELECT * FROM theme WHERE id = ? AND deleted = false",
+                (rs, rowNum) -> new Theme(
+                        rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getString("description")
+                ), id);
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/theme/ThemeDao.java
+++ b/src/main/java/roomescape/theme/ThemeDao.java
@@ -1,15 +1,15 @@
 package roomescape.theme;
 
+import java.sql.PreparedStatement;
+import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public class ThemeDao {
-    private JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
 
     public ThemeDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -26,7 +26,8 @@ public class ThemeDao {
     public Theme save(Theme theme) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
-            var ps = connection.prepareStatement("INSERT INTO theme(name, description) VALUES (?, ?)", new String[]{"id"});
+            PreparedStatement ps = connection.prepareStatement("INSERT INTO theme(name, description) VALUES (?, ?)",
+                    new String[]{"id"});
             ps.setString(1, theme.getName());
             ps.setString(2, theme.getDescription());
             return ps;

--- a/src/main/java/roomescape/time/Time.java
+++ b/src/main/java/roomescape/time/Time.java
@@ -14,7 +14,6 @@ public class Time {
     }
 
     public Time() {
-
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/time/TimeController.java
+++ b/src/main/java/roomescape/time/TimeController.java
@@ -20,12 +20,12 @@ public class TimeController {
     }
 
     @GetMapping("/times")
-    public List<Time> list() {
+    public List<Time> getAllTime() {
         return timeService.findAll();
     }
 
     @PostMapping("/times")
-    public ResponseEntity<Time> create(@RequestBody Time time) {
+    public ResponseEntity<Time> createTime(@RequestBody Time time) {
         if (time.getValue() == null || time.getValue().isEmpty()) {
             throw new RuntimeException();
         }
@@ -35,7 +35,7 @@ public class TimeController {
     }
 
     @DeleteMapping("/times/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteTime(@PathVariable Long id) {
         timeService.deleteById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/time/TimeController.java
+++ b/src/main/java/roomescape/time/TimeController.java
@@ -1,5 +1,7 @@
 package roomescape.time;
 
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,12 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.util.List;
-
 @RestController
 public class TimeController {
-    private TimeService timeService;
+    private final TimeService timeService;
 
     public TimeController(TimeService timeService) {
         this.timeService = timeService;

--- a/src/main/java/roomescape/time/TimeDao.java
+++ b/src/main/java/roomescape/time/TimeDao.java
@@ -15,15 +15,6 @@ public class TimeDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public List<Time> findAll() {
-        return jdbcTemplate.query(
-                "SELECT * FROM time WHERE deleted = false",
-                (rs, rowNum) -> new Time(
-                        rs.getLong("id"),
-                        rs.getString("time_value"))
-        );
-    }
-
     public Time save(Time time) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         this.jdbcTemplate.update(connection -> {
@@ -34,6 +25,23 @@ public class TimeDao {
         }, keyHolder);
 
         return new Time(keyHolder.getKey().longValue(), time.getValue());
+    }
+
+    public List<Time> findAll() {
+        return jdbcTemplate.query(
+                "SELECT * FROM time WHERE deleted = false",
+                (rs, rowNum) -> new Time(
+                        rs.getLong("id"),
+                        rs.getString("time_value"))
+        );
+    }
+
+    public Time findById(Long id) {
+        return jdbcTemplate.queryForObject("SELECT * FROM time WHERE id = ? AND deleted = false",
+                (rs, rowNum) -> new Time(
+                        rs.getLong("id"),
+                        rs.getString("time_value")
+                ), id);
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/time/TimeDao.java
+++ b/src/main/java/roomescape/time/TimeDao.java
@@ -1,12 +1,11 @@
 package roomescape.time;
 
+import java.sql.PreparedStatement;
+import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
-
-import java.sql.PreparedStatement;
-import java.util.List;
 
 @Repository
 public class TimeDao {
@@ -21,13 +20,15 @@ public class TimeDao {
                 "SELECT * FROM time WHERE deleted = false",
                 (rs, rowNum) -> new Time(
                         rs.getLong("id"),
-                        rs.getString("time_value")));
+                        rs.getString("time_value"))
+        );
     }
 
     public Time save(Time time) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         this.jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement("INSERT INTO time(time_value) VALUES (?)", new String[]{"id"});
+            PreparedStatement ps = connection.prepareStatement("INSERT INTO time(time_value) VALUES (?)",
+                    new String[]{"id"});
             ps.setString(1, time.getValue());
             return ps;
         }, keyHolder);

--- a/src/main/java/roomescape/time/TimeService.java
+++ b/src/main/java/roomescape/time/TimeService.java
@@ -1,15 +1,14 @@
 package roomescape.time;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import roomescape.reservation.Reservation;
 import roomescape.reservation.ReservationDao;
 
-import java.util.List;
-
 @Service
 public class TimeService {
-    private TimeDao timeDao;
-    private ReservationDao reservationDao;
+    private final TimeDao timeDao;
+    private final ReservationDao reservationDao;
 
     public TimeService(TimeDao timeDao, ReservationDao reservationDao) {
         this.timeDao = timeDao;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,5 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+roomescape.auth.jwt.secret=${JWT_SECRET}
+roomescape.auth.jwt.token.expire-length=${JWT_TOKEN_EXPIRE}

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.reservation.ReservationResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -69,4 +70,52 @@ public class MissionStepTest {
                 .getString("name"))
                 .isEqualTo("어드민");
     }
+
+    @Test
+    @DisplayName("로그인한 사용자의 예약이 정상적으로 이루어진다.")
+    void shouldReservation_whenLoginMemberInfo() {
+        String token = loginAndGetToken();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).name()).isEqualTo("어드민");
+    }
+
+    @Test
+    @DisplayName("예약을 위해 입력한 이름이 존재할 경우 입력한 이름으로 예약이 정상적으로 이루어진다.")
+    void shouldReservation_whenInputName() {
+        String token = loginAndGetToken();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured
+                .given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).name()).isEqualTo("브라운");
+    }
 }
+

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,29 +1,31 @@
 package roomescape;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+    private static final String TEST_EMAIL = "admin@email.com";
+    private static final String TEST_PASSWORD = "password";
 
-    @Test
-    void 일단계() {
+    private String loginAndGetToken() {
         Map<String, String> params = new HashMap<>();
-        params.put("email", "admin@email.com");
-        params.put("password", "password");
+        params.put("email", TEST_EMAIL);
+        params.put("password", TEST_PASSWORD);
 
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
                 .when().post("/login")
@@ -31,8 +33,40 @@ public class MissionStepTest {
                 .statusCode(200)
                 .extract();
 
-        String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+        return extractTokenFromSetCookie(response);
+    }
 
+    private String extractTokenFromSetCookie(ExtractableResponse<Response> response) {
+        return response.headers().get("Set-Cookie")
+                .getValue()
+                .split(";")[0]
+                .split("=")[1];
+    }
+
+    @Test
+    @DisplayName("로그인이 정상적으로 이루어진다.")
+    void shouldLogin_whenValidLoginData() {
+        String token = loginAndGetToken();
         assertThat(token).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("로그인 시 정상적으로 사용자 정보가 반환된다.")
+    void shouldReturnUserInfo_whenLogin() {
+        String token = loginAndGetToken();
+
+        ExtractableResponse<Response> checkResponse = RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/login/check")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        assertThat(checkResponse.body()
+                .jsonPath()
+                .getString("name"))
+                .isEqualTo("어드민");
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -17,13 +17,12 @@ import roomescape.reservation.ReservationResponse;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
-    private static final String TEST_EMAIL = "admin@email.com";
-    private static final String TEST_PASSWORD = "password";
+    private static final String PASSWORD = "password";
 
-    private String loginAndGetToken() {
+    private String loginAndGetToken(String email) {
         Map<String, String> params = new HashMap<>();
-        params.put("email", TEST_EMAIL);
-        params.put("password", TEST_PASSWORD);
+        params.put("email", email);
+        params.put("password", PASSWORD);
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
@@ -47,14 +46,14 @@ public class MissionStepTest {
     @Test
     @DisplayName("로그인이 정상적으로 이루어진다.")
     void shouldLogin_whenValidLoginData() {
-        String token = loginAndGetToken();
+        String token = loginAndGetToken("admin@email.com");
         assertThat(token).isNotBlank();
     }
 
     @Test
     @DisplayName("로그인 시 정상적으로 사용자 정보가 반환된다.")
     void shouldReturnUserInfo_whenLogin() {
-        String token = loginAndGetToken();
+        String token = loginAndGetToken("admin@email.com");
 
         ExtractableResponse<Response> checkResponse = RestAssured
                 .given().log().all()
@@ -65,16 +64,13 @@ public class MissionStepTest {
                 .statusCode(200)
                 .extract();
 
-        assertThat(checkResponse.body()
-                .jsonPath()
-                .getString("name"))
-                .isEqualTo("어드민");
+        assertThat(checkResponse.body().jsonPath().getString("name")).isEqualTo("어드민");
     }
 
     @Test
     @DisplayName("로그인한 사용자의 예약이 정상적으로 이루어진다.")
     void shouldReservation_whenLoginMemberInfo() {
-        String token = loginAndGetToken();
+        String token = loginAndGetToken("admin@email.com");
 
         Map<String, String> params = new HashMap<>();
         params.put("date", "2024-03-01");
@@ -97,7 +93,7 @@ public class MissionStepTest {
     @Test
     @DisplayName("예약을 위해 입력한 이름이 존재할 경우 입력한 이름으로 예약이 정상적으로 이루어진다.")
     void shouldReservation_whenInputName() {
-        String token = loginAndGetToken();
+        String token = loginAndGetToken("admin@email.com");
 
         Map<String, String> params = new HashMap<>();
         params.put("date", "2024-03-01");
@@ -117,5 +113,24 @@ public class MissionStepTest {
         assertThat(adminResponse.statusCode()).isEqualTo(201);
         assertThat(adminResponse.as(ReservationResponse.class).name()).isEqualTo("브라운");
     }
-}
 
+    @Test
+    @DisplayName("어드민 권한을 가진 사용자만 어드민 페이지에 접근할 수 있다.")
+    void shouldApproachAdminPage_whenOnlyAdminRole() {
+        String brownToken = loginAndGetToken("brown@email.com");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        String adminToken = loginAndGetToken("admin@email.com");
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
안녕하세요 주노!
미션 제출이 많이 늦었네요.. 죄송합니다 🥲 
잘 부탁드립니다!

---

이번 미션 1단계부터 3단계까지 하면서 고민했던 점과 선택한 이유를 차근차근 말씀드리려고 합니다.

## 1단계
### 패키지 구조
로그인 기능을 구현하기 전에 기존 코드를 살펴보니, 도메인별로만 나눠져 있더라고요.
항상 해오던 방식인 domain 내부의 controller, service, repository를 나눌까 생각이 들었지만, `왜 이 구조가 일반화되어있을까?`에 대한 궁금해졌어요.

제가 생각하는 도메인 기준 패키지 분리의 장점은
1. 수정할 때 해당 도메인 코드가 모여있어 빠르게 찾을 수 있고,
2. 개발자가 ‘여기 있겠지?’ 하고 예상하기 쉽다는 점입니다.

그런데 Reservation 도메인은 Theme, Time 두 도메인과도 연결돼 있는데
Reservation 내부에서 다른 도메인의 Service를 사용하는 게 맞을까?
아니면 Reservation 안에 Theme, Time도 함께 있어야 하는 걸까? 하는 의문이 들었어요.

다른 방법인 계층별로 분리하는 방법도 생각해봤지만 도메인이 적으면 한눈에 찾기 편하지만 도메인이 많아지면 불편할 것 같다는 생각이 들었고 
`도메인이 많다는 기준은 몇 개일까?` 하는 것도 애매해서 결국 도메인 기준 분리에 다시 기울었어요.

그래서 저는 아직 패키지 구조에 대한 기준을 정하지 못해서 도메인 내부에서 더 세분화하지 않았어요.
주노는 이런 패키지 구조를 정할 때 어떤 기준을 가지고 계신지 추가로 제가 기준을 정하는 데에 도움이 될 조언이 있다면 부탁드립니다 🙇🏻‍♀️

## 2단계
### 커스텀 어노테이션의 도입
2단계 키워드인 `HandlerMethodArgumentResolver`를 공부하고, 처음에는 로그인한 사용자 정보를 모든 API에서 쓰기 쉽게 하기 위해`Member.class` 타입을 기준으로 Resolver가 작동하도록 구현했어요.

```java
@Override
public boolean supportsParameter(MethodParameter parameter) {
    return parameter.getParameterType().equals(Member.class);
}
```

그런데 이렇게 하니, 어떤 API가 로그인한 사용자를 필요로 하는지 코드만 보고 알기 어렵고 다른 개발자가 봤을 때도 `이 API는 로그인 사용자가 있어야 하는구나` 하는 게 명확하지 않더라고요.
또, `@RequestBody`와 겹치면 충돌 위험도 있다는 걸 알게 됐습니다.

그래서 로그인한 사용자가 필요하다는 의미를 분명히 하기 위해 `@Login`이라는 커스텀 어노테이션을 만들어 사용하기로 했습니다.

```java
@GetMapping("/check")
public ResponseEntity<MemberResponse> checkLogin(@Login Member member) {
     return ResponseEntity.ok(new MemberResponse(member.getId(), member.getName(), member.getEmail()));
}
```

## 3단계
### 관리자 권한 확인 (HandlerInterceptor)

처음에는 아래처럼 쿠키에서 직접 `Member`를 꺼내서 role을 확인하려 했어요.

```java
@Override
public boolean preHandle(@NotNull HttpServletRequest request,
                         @NotNull HttpServletResponse response,
                         @NotNull Object handler) {
    try {
        Member member = authService.findMemberByToken(request);
        if (!"ADMIN".equals(member.getRole())) {
            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
            return false;
        }
        return true;
    } catch (Exception e) {
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        return false;
    }
}
```

하지만, 요청이 오기 전 단계에서 DB까지 조회하는 게 무겁고 부적절하다고 생각했어요.
이미 토큰 안에 name과 role이 포함되어 있으니 토큰만 보고 권한을 판단하는 게 효율적이라 판단하게 되었습니다!

그리고 쿠키 관련 코드가 여러 군데에 중복되는 것도 보여서
- 로그인/로그아웃 시 쿠키를 설정하고 해제하는 부분은 `JwtCookieProvider`에서 담당하도록 했고,
- HTTP 요청에서 쿠키를 꺼내 토큰을 추출하는 부분은 `JwtTokenExtractor`에서 담당하도록 분리해 보았습니다.

## 🤔 궁금한 점
- 현업에서도 커스텀 어노테이션을 자주 사용하나요?
- 주노의 패키지 구조에 대한 의견이 궁금합니다!
- 제가 고민한 방향이 코드 일관성이나 설계 면에서 어긋나는 부분이 있을까요?