### PR TITLE
[그리디] 강동현 Spring MVC(인증) 1,2,3 단계 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+application-local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.0.0'
 

--- a/src/main/java/roomescape/WebConfig.java
+++ b/src/main/java/roomescape/WebConfig.java
@@ -2,7 +2,9 @@ package roomescape;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.auth.AdminAuthInterceptor;
 import roomescape.auth.LoginMemberArgumentResolver;
 
 import java.util.List;
@@ -14,6 +16,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginMemberArgumentResolver(secretKey));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAuthInterceptor(secretKey))
+                .addPathPatterns("/admin", "/admin/**");
     }
 }
 

--- a/src/main/java/roomescape/WebConfig.java
+++ b/src/main/java/roomescape/WebConfig.java
@@ -1,0 +1,20 @@
+package roomescape;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import roomescape.auth.LoginMemberArgumentResolver;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final String secretKey = "temporary-secret-key";
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(secretKey));
+    }
+}
+
+

--- a/src/main/java/roomescape/WebConfig.java
+++ b/src/main/java/roomescape/WebConfig.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    private final String secretKey = "temporary-secret-key";
+    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/roomescape/WebConfig.java
+++ b/src/main/java/roomescape/WebConfig.java
@@ -1,5 +1,6 @@
 package roomescape;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -11,7 +12,8 @@ import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+    @Value("${roomescape.auth.jwt.secret}")
+    private String secretKey;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/roomescape/auth/AdminAuthInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminAuthInterceptor.java
@@ -1,0 +1,58 @@
+package roomescape.auth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AdminAuthInterceptor implements HandlerInterceptor {
+
+    private final String secretKey;
+
+    public AdminAuthInterceptor(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = extractTokenFromCookie(request.getCookies());
+        if (token.isEmpty()) {
+            response.setStatus(401);
+            return false;
+        }
+
+        try {
+            var claims = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String role = claims.get("role", String.class);
+            if (!"ADMIN".equals(role)) {
+                response.setStatus(401);
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            response.setStatus(401);
+            return false;
+        }
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null || cookies.length == 0) {
+            return "";
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+}
+
+

--- a/src/main/java/roomescape/auth/AdminAuthInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminAuthInterceptor.java
@@ -1,11 +1,11 @@
 package roomescape.auth;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
+import roomescape.util.JwtUtil;
 
 public class AdminAuthInterceptor implements HandlerInterceptor {
 
@@ -17,19 +17,14 @@ public class AdminAuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        String token = extractTokenFromCookie(request.getCookies());
+        String token = JwtUtil.extractTokenFromCookies(request.getCookies());
         if (token.isEmpty()) {
             response.setStatus(401);
             return false;
         }
 
         try {
-            var claims = Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-
+            Claims claims = JwtUtil.parseClaims(token, secretKey);
             String role = claims.get("role", String.class);
             if (!"ADMIN".equals(role)) {
                 response.setStatus(401);
@@ -40,18 +35,6 @@ public class AdminAuthInterceptor implements HandlerInterceptor {
             response.setStatus(401);
             return false;
         }
-    }
-
-    private String extractTokenFromCookie(Cookie[] cookies) {
-        if (cookies == null || cookies.length == 0) {
-            return "";
-        }
-        for (Cookie cookie : cookies) {
-            if ("token".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return "";
     }
 }
 

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,62 @@
+package roomescape.auth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import roomescape.member.LoginMember;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final String secretKey;
+
+    public LoginMemberArgumentResolver(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = extractTokenFromCookie(request.getCookies());
+
+        if (token.isEmpty()) {
+            return null;
+        }
+
+        var claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Long id = Long.valueOf(claims.getSubject());
+        String name = claims.get("name", String.class);
+        String role = claims.get("role", String.class);
+
+        return new LoginMember(id, name, null, role);
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null || cookies.length == 0) {
+            return "";
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+}
+
+

--- a/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,7 +1,6 @@
 package roomescape.auth;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -10,6 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import roomescape.member.LoginMember;
+import roomescape.util.JwtUtil;
 
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -27,17 +27,13 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String token = extractTokenFromCookie(request.getCookies());
+        String token = JwtUtil.extractTokenFromCookies(request.getCookies());
 
         if (token.isEmpty()) {
             return null;
         }
 
-        var claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = JwtUtil.parseClaims(token, secretKey);
 
         Long id = Long.valueOf(claims.getSubject());
         String name = claims.get("name", String.class);
@@ -45,18 +41,4 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
         return new LoginMember(id, name, null, role);
     }
-
-    private String extractTokenFromCookie(Cookie[] cookies) {
-        if (cookies == null || cookies.length == 0) {
-            return "";
-        }
-        for (Cookie cookie : cookies) {
-            if ("token".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return "";
-    }
 }
-
-

--- a/src/main/java/roomescape/member/LoginMember.java
+++ b/src/main/java/roomescape/member/LoginMember.java
@@ -1,0 +1,33 @@
+package roomescape.member;
+
+public class LoginMember {
+    private Long id;
+    private String name;
+    private String email;
+    private String role;
+
+    public LoginMember(Long id, String name, String email, String role) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}
+
+

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +17,8 @@ import java.net.URI;
 @RestController
 public class MemberController {
     private MemberService memberService;
-    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+    @Value("${roomescape.auth.jwt.secret}")
+    private String secretKey;
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -16,6 +16,7 @@ import java.net.URI;
 @RestController
 public class MemberController {
     private MemberService memberService;
+    private final String secretKey = "temporary-secret-key";
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
@@ -31,7 +32,6 @@ public class MemberController {
     public ResponseEntity login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
         Member member = memberService.login(memberRequest.getEmail(), memberRequest.getPassword());
 
-        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
         String accessToken = Jwts.builder()
                 .setSubject(member.getId().toString())
                 .claim("name", member.getName())
@@ -51,7 +51,6 @@ public class MemberController {
     public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
         String token = extractTokenFromCookie(request.getCookies());
 
-        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
         String name = Jwts.parserBuilder()
                 .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .build()

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -1,5 +1,7 @@
 package roomescape.member;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +25,26 @@ public class MemberController {
     public ResponseEntity createMember(@RequestBody MemberRequest memberRequest) {
         MemberResponse member = memberService.createMember(memberRequest);
         return ResponseEntity.created(URI.create("/members/" + member.getId())).body(member);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
+        Member member = memberService.login(memberRequest.getEmail(), memberRequest.getPassword());
+
+        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+        String accessToken = Jwts.builder()
+                .setSubject(member.getId().toString())
+                .claim("name", member.getName())
+                .claim("role", member.getRole())
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+
+        Cookie cookie = new Cookie("token", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/logout")

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -32,12 +32,7 @@ public class MemberController {
     public ResponseEntity login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
         Member member = memberService.login(memberRequest.getEmail(), memberRequest.getPassword());
 
-        String accessToken = Jwts.builder()
-                .setSubject(member.getId().toString())
-                .claim("name", member.getName())
-                .claim("role", member.getRole())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
+        String accessToken = createToken(member);
 
         Cookie cookie = new Cookie("token", accessToken);
         cookie.setHttpOnly(true);
@@ -60,6 +55,15 @@ public class MemberController {
 
         MemberResponse body = new MemberResponse(null, name, null);
         return ResponseEntity.ok(body);
+    }
+
+    private String createToken(Member member) {
+        return Jwts.builder()
+                .setSubject(member.getId().toString())
+                .claim("name", member.getName())
+                .claim("role", member.getRole())
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
     }
 
     private String extractTokenFromCookie(Cookie[] cookies) {

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -16,7 +16,7 @@ import java.net.URI;
 @RestController
 public class MemberController {
     private MemberService memberService;
-    private final String secretKey = "temporary-secret-key";
+    private final String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
@@ -57,7 +57,7 @@ public class MemberController {
         return ResponseEntity.ok(body);
     }
 
-    private String createToken(Member member) {
+    public String createToken(Member member) {
         return Jwts.builder()
                 .setSubject(member.getId().toString())
                 .claim("name", member.getName())
@@ -65,6 +65,13 @@ public class MemberController {
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
     }
+    
+
+    public String createTokenFromEmailAndPassword(String email, String password) {
+        Member member = memberService.login(email, password);
+        return createToken(member);
+    }
+
 
     private String extractTokenFromCookie(Cookie[] cookies) {
         if (cookies == null || cookies.length == 0) {

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -47,6 +47,34 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/login/check")
+    public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
+        String token = extractTokenFromCookie(request.getCookies());
+
+        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+        String name = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("name", String.class);
+
+        MemberResponse body = new MemberResponse(null, name, null);
+        return ResponseEntity.ok(body);
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null || cookies.length == 0) {
+            return "";
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+
     @PostMapping("/logout")
     public ResponseEntity logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("token", "");

--- a/src/main/java/roomescape/member/MemberDao.java
+++ b/src/main/java/roomescape/member/MemberDao.java
@@ -40,6 +40,19 @@ public class MemberDao {
         );
     }
 
+    public Member findById(Long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT id, name, email, role FROM member WHERE id = ?",
+                (rs, rowNum) -> new Member(
+                        rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getString("email"),
+                        rs.getString("role")
+                ),
+                id
+        );
+    }
+
     public Member findByName(String name) {
         return jdbcTemplate.queryForObject(
                 "SELECT id, name, email, role FROM member WHERE name = ?",

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -14,4 +14,8 @@ public class MemberService {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
+
+    public Member login(String email, String password) {
+        return memberDao.findByEmailAndPassword(email, password);
+    }
 }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.member.LoginMember;
 
 import java.net.URI;
 import java.util.List;
@@ -26,14 +27,22 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember member) {
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
         }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+
+        String effectiveName = reservationRequest.getName() != null ? reservationRequest.getName() : member.getName();
+        ReservationRequest requestWithName = new ReservationRequest(
+                effectiveName,
+                reservationRequest.getDate(),
+                reservationRequest.getTheme(),
+                reservationRequest.getTime()
+        );
+
+        ReservationResponse reservation = reservationService.save(requestWithName);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -27,10 +27,20 @@ public class ReservationController {
         return reservationService.findAll();
     }
 
+    @GetMapping("/admin/reservations")
+    public List<ReservationResponse> adminList() {
+        return reservationService.findAll();
+    }
+
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody @Valid ReservationRequest reservationRequest, LoginMember member) {
 
-        String effectiveName = reservationRequest.getName() != null ? reservationRequest.getName() : member.getName();
+        String effectiveName = reservationRequest.getName() != null && !reservationRequest.getName().isBlank()
+                ? reservationRequest.getName()
+                : (member != null ? member.getName() : null);
+        if (effectiveName == null || effectiveName.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
         ReservationRequest requestWithName = new ReservationRequest(
                 effectiveName,
                 reservationRequest.getDate(),
@@ -43,8 +53,23 @@ public class ReservationController {
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }
 
+    @PostMapping("/admin/reservations")
+    public ResponseEntity adminCreate(@RequestBody @Valid ReservationRequest reservationRequest) {
+        if (reservationRequest.getName() == null || reservationRequest.getName().isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        ReservationResponse reservation = reservationService.save(reservationRequest);
+        return ResponseEntity.created(URI.create("/admin/reservations/" + reservation.getId())).body(reservation);
+    }
+
     @DeleteMapping("/reservations/{id}")
     public ResponseEntity delete(@PathVariable Long id) {
+        reservationService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/admin/reservations/{id}")
+    public ResponseEntity adminDelete(@PathVariable Long id) {
         reservationService.deleteById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -1,6 +1,7 @@
 package roomescape.reservation;
 
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,12 +28,7 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember member) {
-        if (reservationRequest.getDate() == null
-                || reservationRequest.getTheme() == null
-                || reservationRequest.getTime() == null) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity create(@RequestBody @Valid ReservationRequest reservationRequest, LoginMember member) {
 
         String effectiveName = reservationRequest.getName() != null ? reservationRequest.getName() : member.getName();
         ReservationRequest requestWithName = new ReservationRequest(

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -6,6 +6,16 @@ public class ReservationRequest {
     private Long theme;
     private Long time;
 
+    public ReservationRequest() {
+    }
+
+    public ReservationRequest(String name, String date, Long theme, Long time) {
+        this.name = name;
+        this.date = date;
+        this.theme = theme;
+        this.time = time;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/roomescape/reservation/ReservationRequest.java
@@ -1,9 +1,14 @@
 package roomescape.reservation;
 
+import jakarta.validation.constraints.NotNull;
+
 public class ReservationRequest {
     private String name;
+    @NotNull
     private String date;
+    @NotNull
     private Long theme;
+    @NotNull
     private Long time;
 
     public ReservationRequest() {

--- a/src/main/java/roomescape/theme/ThemeController.java
+++ b/src/main/java/roomescape/theme/ThemeController.java
@@ -25,13 +25,30 @@ public class ThemeController {
         return ResponseEntity.created(URI.create("/themes/" + newTheme.getId())).body(newTheme);
     }
 
+    @PostMapping("/admin/themes")
+    public ResponseEntity<Theme> adminCreateTheme(@RequestBody Theme theme) {
+        Theme newTheme = themeDao.save(theme);
+        return ResponseEntity.created(URI.create("/admin/themes/" + newTheme.getId())).body(newTheme);
+    }
+
     @GetMapping("/themes")
     public ResponseEntity<List<Theme>> list() {
         return ResponseEntity.ok(themeDao.findAll());
     }
 
+    @GetMapping("/admin/themes")
+    public ResponseEntity<List<Theme>> adminList() {
+        return ResponseEntity.ok(themeDao.findAll());
+    }
+
     @DeleteMapping("/themes/{id}")
     public ResponseEntity<Void> deleteTheme(@PathVariable Long id) {
+        themeDao.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/admin/themes/{id}")
+    public ResponseEntity<Void> adminDeleteTheme(@PathVariable Long id) {
         themeDao.deleteById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/time/TimeController.java
+++ b/src/main/java/roomescape/time/TimeController.java
@@ -25,6 +25,11 @@ public class TimeController {
         return timeService.findAll();
     }
 
+    @GetMapping("/admin/times")
+    public List<Time> adminList() {
+        return timeService.findAll();
+    }
+
     @PostMapping("/times")
     public ResponseEntity<Time> create(@RequestBody Time time) {
         if (time.getValue() == null || time.getValue().isEmpty()) {
@@ -35,8 +40,23 @@ public class TimeController {
         return ResponseEntity.created(URI.create("/times/" + newTime.getId())).body(newTime);
     }
 
+    @PostMapping("/admin/times")
+    public ResponseEntity<Time> adminCreate(@RequestBody Time time) {
+        if (time.getValue() == null || time.getValue().isEmpty()) {
+            throw new RuntimeException();
+        }
+        Time newTime = timeService.save(time);
+        return ResponseEntity.created(URI.create("/admin/times/" + newTime.getId())).body(newTime);
+    }
+
     @DeleteMapping("/times/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
+        timeService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/admin/times/{id}")
+    public ResponseEntity<Void> adminDelete(@PathVariable Long id) {
         timeService.deleteById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/util/auth/JwtUtil.java
+++ b/src/main/java/roomescape/util/auth/JwtUtil.java
@@ -1,0 +1,33 @@
+package roomescape.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+
+public final class JwtUtil {
+    private JwtUtil() {
+    }
+
+    public static String extractTokenFromCookies(Cookie[] cookies) {
+        if (cookies == null || cookies.length == 0) {
+            return "";
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+
+    public static Claims parseClaims(String token, String secretKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=

--- a/src/main/resources/static/js/reservation.js
+++ b/src/main/resources/static/js/reservation.js
@@ -1,7 +1,7 @@
 let isEditing = false;
-const RESERVATION_API_ENDPOINT = '/reservations';
-const TIME_API_ENDPOINT = '/times';
-const THEME_API_ENDPOINT = '/themes';
+const RESERVATION_API_ENDPOINT = '/admin/reservations';
+const TIME_API_ENDPOINT = '/admin/times';
+const THEME_API_ENDPOINT = '/admin/themes';
 const timesOptions = [];
 const themesOptions = [];
 

--- a/src/main/resources/static/js/theme.js
+++ b/src/main/resources/static/js/theme.js
@@ -1,5 +1,5 @@
 let isEditing = false;
-const API_ENDPOINT = '/themes';
+const API_ENDPOINT = '/admin/themes';
 const cellFields = ['id', 'name', 'description'];
 const createCellFields = ['', createInput(), createInput()];
 function createBody(inputs) {

--- a/src/main/resources/static/js/time.js
+++ b/src/main/resources/static/js/time.js
@@ -1,25 +1,25 @@
 let isEditing = false;
-const API_ENDPOINT = '/times';
-const cellFields = ['id', 'value'];
-const createCellFields = ['', createInput()];
+const API_ENDPOINT = "/admin/times";
+const cellFields = ["id", "value"];
+const createCellFields = ["", createInput()];
 function createBody(inputs) {
   return {
     value: inputs[0].value,
   };
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('add-button').addEventListener('click', addRow);
+document.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("add-button").addEventListener("click", addRow);
   requestRead()
-      .then(render)
-      .catch(error => console.error('Error fetching times:', error));
+    .then(render)
+    .catch((error) => console.error("Error fetching times:", error));
 });
 
 function render(data) {
-  const tableBody = document.getElementById('table-body');
-  tableBody.innerHTML = '';
+  const tableBody = document.getElementById("table-body");
+  tableBody.innerHTML = "";
 
-  data.forEach(item => {
+  data.forEach((item) => {
     const row = tableBody.insertRow();
 
     cellFields.forEach((field, index) => {
@@ -27,14 +27,14 @@ function render(data) {
     });
 
     const actionCell = row.insertCell(row.cells.length);
-    actionCell.appendChild(createActionButton('삭제', 'btn-danger', deleteRow));
+    actionCell.appendChild(createActionButton("삭제", "btn-danger", deleteRow));
   });
 }
 
 function addRow() {
-  if (isEditing) return;  // 이미 편집 중인 경우 추가하지 않음
+  if (isEditing) return; // 이미 편집 중인 경우 추가하지 않음
 
-  const tableBody = document.getElementById('table-body');
+  const tableBody = document.getElementById("table-body");
   const row = tableBody.insertRow();
   isEditing = true;
 
@@ -44,7 +44,7 @@ function addRow() {
 function createAddField(row) {
   createCellFields.forEach((field, index) => {
     const cell = row.insertCell(index);
-    if (typeof field === 'string') {
+    if (typeof field === "string") {
       cell.textContent = field;
     } else {
       cell.appendChild(field);
@@ -52,82 +52,80 @@ function createAddField(row) {
   });
 
   const actionCell = row.insertCell(row.cells.length);
-  actionCell.appendChild(createActionButton('확인', 'btn-custom', saveRow));
-  actionCell.appendChild(createActionButton('취소', 'btn-secondary', () => {
-    row.remove();
-    isEditing = false;
-  }));
+  actionCell.appendChild(createActionButton("확인", "btn-custom", saveRow));
+  actionCell.appendChild(
+    createActionButton("취소", "btn-secondary", () => {
+      row.remove();
+      isEditing = false;
+    })
+  );
 }
 
 function createInput() {
-  const input = document.createElement('input');
-  input.className = 'form-control';
+  const input = document.createElement("input");
+  input.className = "form-control";
   return input;
 }
 
 function createActionButton(label, className, eventListener) {
-  const button = document.createElement('button');
+  const button = document.createElement("button");
   button.textContent = label;
-  button.classList.add('btn', className, 'mr-2');
-  button.addEventListener('click', eventListener);
+  button.classList.add("btn", className, "mr-2");
+  button.addEventListener("click", eventListener);
   return button;
 }
 
 function saveRow(event) {
   const row = event.target.parentNode.parentNode;
-  const inputs = row.querySelectorAll('input');
+  const inputs = row.querySelectorAll("input");
   const body = createBody(inputs);
 
   requestCreate(body)
-      .then(() => {
-        location.reload();
-      })
-      .catch(error => console.error('Error:', error));
+    .then(() => {
+      location.reload();
+    })
+    .catch((error) => console.error("Error:", error));
 
-  isEditing = false;  // isEditing 값을 false로 설정
+  isEditing = false; // isEditing 값을 false로 설정
 }
 
 function deleteRow(event) {
-  const row = event.target.closest('tr');
+  const row = event.target.closest("tr");
   const id = row.cells[0].textContent;
 
   requestDelete(id)
-      .then(() => row.remove())
-      .catch(error => console.error('Error:', error));
+    .then(() => row.remove())
+    .catch((error) => console.error("Error:", error));
 }
-
 
 // request
 
 function requestCreate(data) {
   const requestOptions = {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(data)
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
   };
 
-  return fetch(API_ENDPOINT, requestOptions)
-      .then(response => {
-        if (response.status === 201) return response.json();
-        throw new Error('Create failed');
-      });
+  return fetch(API_ENDPOINT, requestOptions).then((response) => {
+    if (response.status === 201) return response.json();
+    throw new Error("Create failed");
+  });
 }
 
 function requestRead() {
-  return fetch(API_ENDPOINT)
-      .then(response => {
-        if (response.status === 200) return response.json();
-        throw new Error('Read failed');
-      });
+  return fetch(API_ENDPOINT).then((response) => {
+    if (response.status === 200) return response.json();
+    throw new Error("Read failed");
+  });
 }
 
 function requestDelete(id) {
   const requestOptions = {
-    method: 'DELETE',
+    method: "DELETE",
   };
 
-  return fetch(`${API_ENDPOINT}/${id}`, requestOptions)
-      .then(response => {
-        if (response.status !== 204) throw new Error('Delete failed');
-      });
+  return fetch(`${API_ENDPOINT}/${id}`, requestOptions).then((response) => {
+    if (response.status !== 204) throw new Error("Delete failed");
+  });
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -7,6 +7,9 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import roomescape.member.MemberController;
+import roomescape.reservation.ReservationResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    @Autowired
+    private MemberController memberController;
 
     @Test
     void 일단계() {
@@ -38,7 +44,7 @@ public class MissionStepTest {
 
     @Test
     void 이단계() {
-        String token = createToken("admin@email.com", "password");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+        String token = memberController.createTokenFromEmailAndPassword("admin@email.com", "password");
 
         Map<String, String> params = new HashMap<>();
         params.put("date", "2024-03-01");

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -6,8 +6,8 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 import roomescape.member.MemberController;
 import roomescape.reservation.ReservationResponse;
 
@@ -17,7 +17,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Sql(scripts = "/sql/truncate.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public class MissionStepTest {
 
     @Autowired

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -6,7 +6,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 import roomescape.member.MemberController;
 import roomescape.reservation.ReservationResponse;
@@ -20,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Sql(scripts = "/sql/truncate.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public class MissionStepTest {
 
-    @Autowired
-    private MemberController memberController;
+    private final MemberController memberController;
+
+    public MissionStepTest(MemberController memberController) {
+        this.memberController = memberController;
+    }
 
     @Test
     void 일단계() {

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -75,4 +75,23 @@ public class MissionStepTest {
         assertThat(adminResponse.statusCode()).isEqualTo(201);
         assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
     }
+
+    @Test
+    void 삼단계() {
+        String brownToken = memberController.createTokenFromEmailAndPassword("brown@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        String adminToken = memberController.createTokenFromEmailAndPassword("admin@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
+    }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -35,4 +35,38 @@ public class MissionStepTest {
 
         assertThat(token).isNotBlank();
     }
+
+    @Test
+    void 이단계() {
+        String token = createToken("admin@email.com", "password");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+    }
 }

--- a/src/test/resources/sql/truncate.sql
+++ b/src/test/resources/sql/truncate.sql
@@ -1,0 +1,25 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+TRUNCATE TABLE reservation;
+TRUNCATE TABLE member;
+TRUNCATE TABLE theme;
+TRUNCATE TABLE time;
+SET REFERENTIAL_INTEGRITY TRUE;
+
+INSERT INTO member (name, email, password, role)
+VALUES ('어드민', 'admin@email.com', 'password', 'ADMIN'),
+       ('브라운', 'brown@email.com', 'password', 'USER');
+
+INSERT INTO theme (name, description)
+VALUES ('테마1', '테마1입니다.'),
+       ('테마2', '테마2입니다.'),
+       ('테마3', '테마3입니다.');
+
+INSERT INTO time (time_value)
+VALUES ('10:00'),
+       ('12:00'),
+       ('14:00'),
+       ('16:00'),
+       ('18:00'),
+       ('20:00');
+
+


### PR DESCRIPTION
안녕하세요 조승현 리뷰어님!
연속으로 만나뵙게 되어 너무 좋은 것 같습니다!
이번 미션도 잘부탁드립니다~!!🚀🚀

---

## 미션을 진행하며

이번 미션은 저번 미션에 이어 Authorazation 기능을 추가하는 미션이었습니다!
기존 코드를 그대로 사용할까 싶었습니다만,
이전 코드로 덮어씌우고 로그인 기능을 추가하면 변경된 내용을 확인하시기 쉽지 않고, 이미 레포지토리에 이전 단계를 구현해놓은 코드가 존재하기 때문에 해당 레포지토리의 내용 위에 덧대어서 미션을 진행하였습니다.
혹시 이전에 작성한 코드로 미션을 진행해야하는 이유가 있었다면 늦더라도 미션을 다시 진행하겠습니다!

## 파일구조(변경된 파일만)

```

auth/
- AdminAuthInterceptor : 관리자 권한(JWT role) 검증
- LoginMemberArgumentResolver : 쿠키 토큰 → LoginMember 주입

member/
- MemberController : 로그인/로그아웃/상태 조회
- MemberService : 로그인 처리(login)
- MemberDao : 회원 조회
- LoginMember : 로그인 사용자 DTO

reservation/
- ReservationController : LoginMember 기반 예약 처리
- ReservationRequest : 예약 요청 DTO

root/
- WebConfig : Interceptor, ArgumentResolver 등록

```


## 고민한 부분

1. 기존 코드에서대로 GET /login/check에서 토큰의 name 클레임을 그대로 응답하면 단순하지만, 이름 변경/동명이인 이슈를 생각하면 id 기반 조회가 더 안전하다고 생각하여 dao를 수정하였습니다. 

2. 어드민 보호는 어떤 경로에 어디까지 적용할지(예: /admin/**만 vs 도메인 API의 변경 계열까지)에 대해 고민했습니다. 

- 첫 번째로는 /admin/ 경로(관리자 화면 진입)만 막는 방식을 고려했습니다.니다. 이 경우 일반 사용자도 테마/시간 같은 목록 조회(GET)는 가능하지만, 관리자 화면 자체는 접근이 차단됩니다.

-두 번째 선택지는 도메인 API 중 ‘변경’ 요청만 관리자에게 허용하는 방식을 고려했습니다.
예를 들어 테마/시간/예약의 POST·PUT·PATCH·DELETE는 관리자만, GET은 모두 허용처럼 정책을 나눌 수 있습니다. 즉 “읽기는 열고, 쓰기는 막는다”는 구조입니다.

화면 진입 자체를 차단하면 관리자 기능 노출을 즉시 막을 수 있고, 테스트코드 단에서는 해당 방식을 첫번째 방식을 유도하는 것 같아, 우선 첫번째 방식을 적용하였습니다.
이후 보안/무결성 요구가 생긴다면 리팩토링을 진행할 예정입니다!