### PR TITLE
[Spring Data JPA (2차)] 하수한 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.security:spring-security-crypto'
 
     implementation 'dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.0.0'
 

--- a/src/main/java/roomescape/auth/AdminRouteInterceptor.java
+++ b/src/main/java/roomescape/auth/AdminRouteInterceptor.java
@@ -40,7 +40,7 @@ public class AdminRouteInterceptor implements HandlerInterceptor {
         String subject = jwtTokenProvider.getSubject(token);
         Member member = memberService.findById(subject);
 
-        if (member == null || !member.getRole().equals("ADMIN")) {
+        if (member == null || member.getRole() != Role.ADMIN) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             return false;
         }

--- a/src/main/java/roomescape/auth/Role.java
+++ b/src/main/java/roomescape/auth/Role.java
@@ -1,0 +1,6 @@
+package roomescape.auth;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/roomescape/config/PasswordConfig.java
+++ b/src/main/java/roomescape/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/roomescape/controller/TimeController.java
+++ b/src/main/java/roomescape/controller/TimeController.java
@@ -1,5 +1,6 @@
 package roomescape.controller;
 
+import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -51,7 +52,7 @@ public class TimeController {
     }
 
     @GetMapping("/available-times")
-    public ResponseEntity<List<AvailableTime>> availableTimes(@RequestParam String date, @RequestParam Long themeId) {
+    public ResponseEntity<List<AvailableTime>> availableTimes(@RequestParam LocalDate date, @RequestParam Long themeId) {
         return ResponseEntity.ok(timeService.getAvailableTime(date, themeId));
     }
 }

--- a/src/main/java/roomescape/dto/MyReservationResponse.java
+++ b/src/main/java/roomescape/dto/MyReservationResponse.java
@@ -1,9 +1,11 @@
 package roomescape.dto;
 
+import java.time.LocalDate;
+
 public record MyReservationResponse(
         Long id,
         String theme,
-        String date,
+        LocalDate date,
         String time,
         String status
 ) { }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,9 +1,11 @@
 package roomescape.dto;
 
+import java.time.LocalDate;
+
 public record ReservationRequest(
         String name,
         Long memberId,
-        String date,
+        LocalDate date,
         Long theme,
         Long time
 ) { }

--- a/src/main/java/roomescape/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/ReservationResponse.java
@@ -1,12 +1,13 @@
 package roomescape.dto;
 
+import java.time.LocalDate;
 import roomescape.model.Reservation;
 
 public record ReservationResponse(
         Long id,
         String name,
         String theme,
-        String date,
+        LocalDate date,
         String time
 ) {
     public static ReservationResponse from(Reservation reservation) {

--- a/src/main/java/roomescape/dto/WaitingRequest.java
+++ b/src/main/java/roomescape/dto/WaitingRequest.java
@@ -1,7 +1,9 @@
 package roomescape.dto;
 
+import java.time.LocalDate;
+
 public record WaitingRequest(
-        String date,
+        LocalDate date,
         Long theme,
         Long time
 ) {

--- a/src/main/java/roomescape/model/Member.java
+++ b/src/main/java/roomescape/model/Member.java
@@ -2,9 +2,12 @@ package roomescape.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import roomescape.auth.Role;
 
 @Entity
 public class Member {
@@ -22,18 +25,19 @@ public class Member {
     private String password;
 
     @Column(nullable = false)
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     public Member() { }
 
-    public Member(Long id, String name, String email, String role) {
+    public Member(Long id, String name, String email, Role role) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.role = role;
     }
 
-    public Member(String name, String email, String password, String role) {
+    public Member(String name, String email, String password, Role role) {
         this.name = name;
         this.email = email;
         this.password = password;
@@ -56,7 +60,7 @@ public class Member {
         return password;
     }
 
-    public String getRole() {
+    public Role getRole() {
         return role;
     }
 }

--- a/src/main/java/roomescape/model/Reservation.java
+++ b/src/main/java/roomescape/model/Reservation.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 
 @Entity
 public class Reservation {
@@ -25,7 +26,7 @@ public class Reservation {
     private Member member;
 
     @Column(nullable = false)
-    private String date;
+    private LocalDate date;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_id")
@@ -35,7 +36,7 @@ public class Reservation {
     @JoinColumn(name = "theme_id")
     private Theme theme;
 
-    public Reservation(Long id, String name, String date, Time time, Theme theme) {
+    public Reservation(Long id, String name, LocalDate date, Time time, Theme theme) {
         this.id = id;
         this.name = name;
         this.date = date;
@@ -43,14 +44,14 @@ public class Reservation {
         this.theme = theme;
     }
 
-    public Reservation(String name, String date, Time time, Theme theme) {
+    public Reservation(String name, LocalDate date, Time time, Theme theme) {
         this.name = name;
         this.date = date;
         this.time = time;
         this.theme = theme;
     }
 
-    public Reservation(Member member, String date, Time time, Theme theme) {
+    public Reservation(Member member, LocalDate date, Time time, Theme theme) {
         this.member = member;
         this.date = date;
         this.time = time;
@@ -71,7 +72,7 @@ public class Reservation {
         return member;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 

--- a/src/main/java/roomescape/model/Reservation.java
+++ b/src/main/java/roomescape/model/Reservation.java
@@ -20,18 +20,18 @@ public class Reservation {
     private String name;
 
     // 사용자 예약용
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Column(nullable = false)
     private String date;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_id")
     private Time time;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id")
     private Theme theme;
 

--- a/src/main/java/roomescape/model/Theme.java
+++ b/src/main/java/roomescape/model/Theme.java
@@ -5,8 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE theme SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Theme {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/roomescape/model/Time.java
+++ b/src/main/java/roomescape/model/Time.java
@@ -5,8 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
+@SQLDelete(sql = "UPDATE time SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Time {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/roomescape/model/Waiting.java
+++ b/src/main/java/roomescape/model/Waiting.java
@@ -15,18 +15,18 @@ public class Waiting {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Column(nullable = false)
     private String date;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_id", nullable = false)
     private Time time;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id", nullable = false)
     private Theme theme;
 

--- a/src/main/java/roomescape/model/Waiting.java
+++ b/src/main/java/roomescape/model/Waiting.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 
 @Entity
 @Table(
@@ -29,7 +30,7 @@ public class Waiting {
     private Member member;
 
     @Column(nullable = false)
-    private String date;
+    private LocalDate date;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "time_id", nullable = false)
@@ -41,7 +42,7 @@ public class Waiting {
 
     public Waiting() { }
 
-    public Waiting(Member member, String date, Time time, Theme theme) {
+    public Waiting(Member member, LocalDate date, Time time, Theme theme) {
         this.member = member;
         this.date = date;
         this.time = time;
@@ -56,7 +57,7 @@ public class Waiting {
         return member;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 

--- a/src/main/java/roomescape/model/Waiting.java
+++ b/src/main/java/roomescape/model/Waiting.java
@@ -8,8 +8,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 @Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        columnNames = { "member_id", "date", "time_id", "theme_id" }
+                )
+        }
+)
 public class Waiting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/roomescape/repository/MemberRepository.java
+++ b/src/main/java/roomescape/repository/MemberRepository.java
@@ -1,35 +1,9 @@
 package roomescape.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.model.Member;
 
-@Repository
-public class MemberRepository {
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    public Member save(Member member) {
-        entityManager.persist(member);
-        return member;
-    }
-
-    public Optional<Member> findByEmailAndPassword(String email, String password) {
-        String jpql = "SELECT m FROM Member m WHERE m.email = :email AND m.password = :password";
-        TypedQuery<Member> query = entityManager.createQuery(jpql, Member.class);
-        query.setParameter("email", email);
-        query.setParameter("password", password);
-
-        List<Member> members = query.getResultList();
-        return members.stream().findFirst();
-    }
-
-    public Optional<Member> findById(String id) {
-        Member member = entityManager.find(Member.class, Long.parseLong(id));
-        return Optional.ofNullable(member);
-    }
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/roomescape/repository/MemberRepository.java
+++ b/src/main/java/roomescape/repository/MemberRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.model.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmailAndPassword(String email, String password);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,5 +1,6 @@
 package roomescape.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7,18 +8,18 @@ import org.springframework.data.repository.query.Param;
 import roomescape.model.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    List<Reservation> findByDateAndThemeId(String date, Long themeId);
+    List<Reservation> findByDateAndThemeId(LocalDate date, Long themeId);
 
     List<Reservation> findByMemberId(Long memberId);
 
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END " +
            "FROM Reservation r " +
            "WHERE r.date = :date AND r.time.id = :timeId AND r.theme.id = :themeId")
-    boolean existsByDateAndTimeAndTheme(@Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
+    boolean existsByDateAndTimeAndTheme(@Param("date") LocalDate date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END " +
            "FROM Reservation r " +
            "WHERE r.member.id = :memberId AND r.date = :date " +
            "AND r.time.id = :timeId AND r.theme.id = :themeId")
-    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
+    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") LocalDate date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,83 +1,24 @@
 package roomescape.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import org.springframework.stereotype.Repository;
-import roomescape.dto.ReservationRequest;
-import roomescape.model.Member;
-import roomescape.model.Reservation;
-import roomescape.model.Theme;
-import roomescape.model.Time;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import roomescape.model.Reservation;
 
-@Repository
-public class ReservationRepository {
-    @PersistenceContext
-    private EntityManager entityManager;
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByDateAndThemeId(String date, Long themeId);
 
-    public List<Reservation> findAll() {
-        String jpql = "SELECT r FROM Reservation r";
-        TypedQuery<Reservation> query = entityManager.createQuery(jpql, Reservation.class);
-        return query.getResultList();
-    }
+    List<Reservation> findByMemberId(Long memberId);
 
-    public Reservation save(ReservationRequest request) {
-        Time time = entityManager.find(Time.class, request.time());
-        Theme theme = entityManager.find(Theme.class, request.theme());
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END " +
+           "FROM Reservation r " +
+           "WHERE r.date = :date AND r.time.id = :timeId AND r.theme.id = :themeId")
+    boolean existsByDateAndTimeAndTheme(@Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 
-        Reservation reservation;
-
-        if (request.memberId() != null) {
-            Member member = entityManager.find(Member.class, request.memberId());
-            reservation = new Reservation(member, request.date(), time, theme);
-        } else {
-            reservation = new Reservation(request.name(), request.date(), time, theme);
-        }
-
-        entityManager.persist(reservation);
-        return reservation;
-    }
-
-    public void deleteById(Long id) {
-        Reservation reservation = entityManager.find(Reservation.class, id);
-        if (reservation != null) {
-            entityManager.remove(reservation);
-        }
-    }
-
-    public List<Reservation> findByDateAndThemeId(String date, Long themeId) {
-        String jpql = "SELECT r FROM Reservation r WHERE r.date = :date AND r.theme.id = :themeId";
-        TypedQuery<Reservation> query = entityManager.createQuery(jpql, Reservation.class);
-        query.setParameter("date", date);
-        query.setParameter("themeId", themeId);
-        return query.getResultList();
-    }
-
-    public List<Reservation> findByMemberId(Long memberId) {
-        String jpql = "SELECT r FROM Reservation r WHERE r.member.id = :memberId";
-        TypedQuery<Reservation> query = entityManager.createQuery(jpql, Reservation.class);
-        query.setParameter("memberId", memberId);
-        return query.getResultList();
-    }
-
-    public boolean existsByDateAndTimeAndTheme(String date, Long timeId, Long themeId) {
-        String jpql = "SELECT COUNT(r) FROM Reservation r WHERE r.date = :date AND r.time.id = :timeId AND r.theme.id = :themeId";
-        TypedQuery<Long> query = entityManager.createQuery(jpql, Long.class);
-        query.setParameter("date", date);
-        query.setParameter("timeId", timeId);
-        query.setParameter("themeId", themeId);
-        return query.getSingleResult() > 0;
-    }
-
-    public boolean existsByMemberAndDateAndTimeAndTheme(Long memberId, String date, Long timeId, Long themeId) {
-        String jpql = "SELECT COUNT(r) FROM Reservation r WHERE r.member.id = :memberId AND r.date = :date AND r.time.id = :timeId AND r.theme.id = :themeId";
-        TypedQuery<Long> query = entityManager.createQuery(jpql, Long.class);
-        query.setParameter("memberId", memberId);
-        query.setParameter("date", date);
-        query.setParameter("timeId", timeId);
-        query.setParameter("themeId", themeId);
-        return query.getSingleResult() > 0;
-    }
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END " +
+           "FROM Reservation r " +
+           "WHERE r.member.id = :memberId AND r.date = :date " +
+           "AND r.time.id = :timeId AND r.theme.id = :themeId")
+    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 }

--- a/src/main/java/roomescape/repository/ThemeRepository.java
+++ b/src/main/java/roomescape/repository/ThemeRepository.java
@@ -1,33 +1,6 @@
 package roomescape.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.model.Theme;
 
-import java.util.List;
-
-@Repository
-public class ThemeRepository {
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    public List<Theme> findAll() {
-        String jpql = "SELECT t FROM Theme t WHERE t.deleted = false";
-        TypedQuery<Theme> query = entityManager.createQuery(jpql, Theme.class);
-        return query.getResultList();
-    }
-
-    public Theme save(Theme theme) {
-        entityManager.persist(theme);
-        return theme;
-    }
-
-    public void deleteById(Long id) {
-        Theme theme = entityManager.find(Theme.class, id);
-        if (theme != null) {
-            theme.delete();
-        }
-    }
-}
+public interface ThemeRepository extends JpaRepository<Theme, Long> { }

--- a/src/main/java/roomescape/repository/TimeRepository.java
+++ b/src/main/java/roomescape/repository/TimeRepository.java
@@ -1,40 +1,6 @@
 package roomescape.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
-import java.util.Optional;
-import org.springframework.stereotype.Repository;
-import roomescape.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
 import roomescape.model.Time;
 
-import java.util.List;
-
-@Repository
-public class TimeRepository {
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    public List<Time> findAll() {
-        String jpql = "SELECT t FROM Time t WHERE t.deleted = false";
-        TypedQuery<Time> query = entityManager.createQuery(jpql, Time.class);
-        return query.getResultList();
-    }
-
-    public Optional<Time> findById(Long id) {
-        Time time = entityManager.find(Time.class, id);
-        return Optional.ofNullable(time);
-    }
-
-    public Time save(Time time) {
-        entityManager.persist(time);
-        return time;
-    }
-
-    public void deleteById(Long id) {
-        Time time = entityManager.find(Time.class, id);
-        if (time != null) {
-            time.delete();
-        }
-    }
-}
+public interface TimeRepository extends JpaRepository<Time, Long> { }

--- a/src/main/java/roomescape/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/repository/WaitingRepository.java
@@ -1,80 +1,32 @@
 package roomescape.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.stereotype.Repository;
-import roomescape.dto.WaitingRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import roomescape.dto.WaitingWithRank;
-import roomescape.model.Member;
-import roomescape.model.Theme;
-import roomescape.model.Time;
 import roomescape.model.Waiting;
 
-@Repository
-public class WaitingRepository {
-    @PersistenceContext
-    private EntityManager entityManager;
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+    @Query("SELECT new roomescape.dto.WaitingWithRank(" +
+           "   w, " +
+           "   (SELECT COUNT(w2) + 1 " +
+           "    FROM Waiting w2 " +
+           "    WHERE w2.theme = w.theme " +
+           "      AND w2.date = w.date " +
+           "      AND w2.time = w.time " +
+           "      AND w2.id < w.id)" +
+           ") " +
+           "FROM Waiting w " +
+           "WHERE w.member.id = :memberId")
+    List<WaitingWithRank> findWaitingsWithRankByMemberId(@Param("memberId") Long memberId);
 
-    public Optional<Waiting> findById(Long id) {
-        Waiting waiting = entityManager.find(Waiting.class, id);
-        return Optional.ofNullable(waiting);
-    }
+    @Query("SELECT CASE WHEN COUNT(w) > 0 THEN true ELSE false END " +
+           "FROM Waiting w " +
+           "WHERE w.member.id = :memberId AND w.date = :date " +
+           "AND w.time.id = :timeId AND w.theme.id = :themeId")
+    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 
-    public boolean existsByMemberAndDateAndTimeAndTheme(Long memberId, String date, Long timeId, Long themeId) {
-        String jpql = "SELECT COUNT(w) FROM Waiting w WHERE w.member.id = :memberId AND w.date = :date AND w.time.id = :timeId AND w.theme.id = :themeId";
-        TypedQuery<Long> query = entityManager.createQuery(jpql, Long.class);
-        query.setParameter("memberId", memberId);
-        query.setParameter("date", date);
-        query.setParameter("timeId", timeId);
-        query.setParameter("themeId", themeId);
-        return query.getSingleResult() > 0;
-    }
-
-    public Waiting save(WaitingRequest request, Member member) {
-        Time time = entityManager.find(Time.class, request.time());
-        Theme theme = entityManager.find(Theme.class, request.theme());
-
-        Waiting waiting = new Waiting(member, request.date(), time, theme);
-
-        entityManager.persist(waiting);
-        return waiting;
-    }
-
-    public void deleteById(Long id) {
-        Waiting waiting = entityManager.find(Waiting.class, id);
-        if (waiting != null) {
-            entityManager.remove(waiting);
-        }
-    }
-
-    public Long countByDateAndTimeAndTheme(String date, Long timeId, Long themeId) {
-        String jpql = "SELECT COUNT(w) FROM Waiting w WHERE w.date = :date AND w.time.id = :timeId AND w.theme.id = :themeId";
-        TypedQuery<Long> query = entityManager.createQuery(jpql, Long.class);
-        query.setParameter("date", date);
-        query.setParameter("timeId", timeId);
-        query.setParameter("themeId", themeId);
-        return query.getSingleResult();
-    }
-
-    public List<WaitingWithRank> findWaitingsWithRankByMemberId(Long memberId) {
-        String jpql =
-                "SELECT new roomescape.dto.WaitingWithRank(" +
-                        "   w, " +
-                        "   (SELECT COUNT(w2) + 1 " +
-                        "    FROM Waiting w2 " +
-                        "    WHERE w2.theme = w.theme " +
-                        "      AND w2.date = w.date " +
-                        "      AND w2.time = w.time " +
-                        "      AND w2.id < w.id)" +
-                        ") " +
-                        "FROM Waiting w " +
-                        "WHERE w.member.id = :memberId";
-        TypedQuery<WaitingWithRank> query = entityManager.createQuery(jpql, WaitingWithRank.class);
-        query.setParameter("memberId", memberId);
-
-        return query.getResultList();
-    }
+    @Query("SELECT COUNT(w) FROM Waiting w WHERE w.date = :date AND w.time.id = :timeId AND w.theme.id = :themeId")
+    Long countByDateAndTimeAndTheme(@Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 }

--- a/src/main/java/roomescape/repository/WaitingRepository.java
+++ b/src/main/java/roomescape/repository/WaitingRepository.java
@@ -1,5 +1,6 @@
 package roomescape.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,8 +26,8 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
            "FROM Waiting w " +
            "WHERE w.member.id = :memberId AND w.date = :date " +
            "AND w.time.id = :timeId AND w.theme.id = :themeId")
-    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
+    boolean existsByMemberAndDateAndTimeAndTheme(@Param("memberId") Long memberId, @Param("date") LocalDate date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 
     @Query("SELECT COUNT(w) FROM Waiting w WHERE w.date = :date AND w.time.id = :timeId AND w.theme.id = :themeId")
-    Long countByDateAndTimeAndTheme(@Param("date") String date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
+    Long countByDateAndTimeAndTheme(@Param("date") LocalDate date, @Param("timeId") Long timeId, @Param("themeId") Long themeId);
 }

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     }
 
     public Member findById(String id) {
-        return memberRepository.findById(id).orElseThrow(() -> new UnauthorizedException("유효하지 않은 토큰입니다."));
+        return memberRepository.findById(Long.parseLong(id)).orElseThrow(() -> new UnauthorizedException("유효하지 않은 토큰입니다."));
     }
 
     public Member authenticate(String email, String password) {

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -2,6 +2,7 @@ package roomescape.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.auth.Role;
 import roomescape.repository.MemberRepository;
 import roomescape.dto.MemberRequest;
 import roomescape.dto.MemberResponse;
@@ -18,7 +19,7 @@ public class MemberService {
     }
 
     public MemberResponse create(MemberRequest memberRequest) {
-        Member member = memberRepository.save(new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), "USER"));
+        Member member = memberRepository.save(new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), Role.USER));
 
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -1,5 +1,6 @@
 package roomescape.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.auth.Role;
@@ -13,13 +14,16 @@ import roomescape.model.Member;
 @Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public MemberService(MemberRepository memberRepository) {
+    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public MemberResponse create(MemberRequest memberRequest) {
-        Member member = memberRepository.save(new Member(memberRequest.name(), memberRequest.email(), memberRequest.password(), Role.USER));
+        String encodedPassword = passwordEncoder.encode(memberRequest.password());
+        Member member = memberRepository.save(new Member(memberRequest.name(), memberRequest.email(), encodedPassword, Role.USER));
 
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
     }
@@ -29,6 +33,13 @@ public class MemberService {
     }
 
     public Member authenticate(String email, String password) {
-        return memberRepository.findByEmailAndPassword(email, password).orElseThrow(() -> new UnauthorizedException("유효한 인증 정보가 없습니다."));
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UnauthorizedException("유효한 인증 정보가 없습니다."));
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new UnauthorizedException("유효한 인증 정보가 없습니다.");
+        }
+
+        return member;
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -9,11 +9,15 @@ import org.springframework.util.StringUtils;
 import roomescape.dto.MyReservationResponse;
 import roomescape.model.Waiting;
 import roomescape.repository.ReservationRepository;
+import roomescape.repository.TimeRepository;
+import roomescape.repository.ThemeRepository;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 import roomescape.exception.BadRequestException;
 import roomescape.model.Member;
 import roomescape.model.Reservation;
+import roomescape.model.Theme;
+import roomescape.model.Time;
 import roomescape.repository.WaitingRepository;
 
 @Service
@@ -21,10 +25,15 @@ import roomescape.repository.WaitingRepository;
 public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final WaitingRepository waitingRepository;
+    private final TimeRepository timeRepository;
+    private final ThemeRepository themeRepository;
 
-    public ReservationService(ReservationRepository reservationRepository, WaitingRepository waitingRepository) {
+    public ReservationService(ReservationRepository reservationRepository, WaitingRepository waitingRepository,
+                            TimeRepository timeRepository, ThemeRepository themeRepository) {
         this.reservationRepository = reservationRepository;
         this.waitingRepository = waitingRepository;
+        this.timeRepository = timeRepository;
+        this.themeRepository = themeRepository;
     }
 
     public ReservationResponse create(ReservationRequest request, Member member) {
@@ -34,17 +43,20 @@ public class ReservationService {
             throw new BadRequestException("이미 예약이 존재합니다.");
         }
 
-        ReservationRequest finalized;
+        Time time = timeRepository.findById(request.time())
+                .orElseThrow(() -> new BadRequestException("시간이 존재하지 않습니다."));
+        Theme theme = themeRepository.findById(request.theme())
+                .orElseThrow(() -> new BadRequestException("테마가 존재하지 않습니다."));
 
+        Reservation reservation;
         if (StringUtils.hasText(request.name())) {
-            finalized = new ReservationRequest(request.name(), null, request.date(), request.time(), request.theme());
+            reservation = new Reservation(request.name(), request.date(), time, theme);
         } else {
-            finalized = new ReservationRequest(null, member.getId(), request.date(), request.time(), request.theme());
+            reservation = new Reservation(member, request.date(), time, theme);
         }
 
-        Reservation reservation = reservationRepository.save(finalized);
-
-        return ReservationResponse.from(reservation);
+        Reservation saved = reservationRepository.save(reservation);
+        return ReservationResponse.from(saved);
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/service/TimeService.java
+++ b/src/main/java/roomescape/service/TimeService.java
@@ -1,5 +1,6 @@
 package roomescape.service;
 
+import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import roomescape.repository.TimeRepository;
@@ -23,7 +24,7 @@ public class TimeService {
         this.reservationRepository = reservationRepository;
     }
 
-    public List<AvailableTime> getAvailableTime(String date, Long themeId) {
+    public List<AvailableTime> getAvailableTime(LocalDate date, Long themeId) {
         List<Reservation> reservations = reservationRepository.findByDateAndThemeId(date, themeId);
         List<Time> times = timeRepository.findAll();
 

--- a/src/main/java/roomescape/service/WaitingService.java
+++ b/src/main/java/roomescape/service/WaitingService.java
@@ -6,8 +6,12 @@ import roomescape.dto.WaitingRequest;
 import roomescape.dto.WaitingResponse;
 import roomescape.exception.BadRequestException;
 import roomescape.model.Member;
+import roomescape.model.Theme;
+import roomescape.model.Time;
 import roomescape.model.Waiting;
 import roomescape.repository.ReservationRepository;
+import roomescape.repository.ThemeRepository;
+import roomescape.repository.TimeRepository;
 import roomescape.repository.WaitingRepository;
 
 @Service
@@ -15,10 +19,15 @@ import roomescape.repository.WaitingRepository;
 public class WaitingService {
     private final ReservationRepository reservationRepository;
     private final WaitingRepository waitingRepository;
+    private final TimeRepository timeRepository;
+    private final ThemeRepository themeRepository;
 
-    public WaitingService(ReservationRepository reservationRepository, WaitingRepository waitingRepository) {
+    public WaitingService(ReservationRepository reservationRepository, WaitingRepository waitingRepository,
+                         TimeRepository timeRepository, ThemeRepository themeRepository) {
         this.reservationRepository = reservationRepository;
         this.waitingRepository = waitingRepository;
+        this.timeRepository = timeRepository;
+        this.themeRepository = themeRepository;
     }
 
     public WaitingResponse create(WaitingRequest request, Member member) {
@@ -32,11 +41,17 @@ public class WaitingService {
             throw new BadRequestException("이미 예약 대기 중입니다.");
         }
 
-        Waiting waiting = waitingRepository.save(request, member);
+        Time time = timeRepository.findById(request.time())
+                .orElseThrow(() -> new BadRequestException("시간이 존재하지 않습니다."));
+        Theme theme = themeRepository.findById(request.theme())
+                .orElseThrow(() -> new BadRequestException("테마가 존재하지 않습니다."));
+
+        Waiting waiting = new Waiting(member, request.date(), time, theme);
+        Waiting saved = waitingRepository.save(waiting);
 
         Long waitingNumber = waitingRepository.countByDateAndTimeAndTheme(request.date(), request.time(), request.theme());
 
-        return new WaitingResponse(waiting.getId(), waitingNumber);
+        return new WaitingResponse(saved.getId(), waitingNumber);
     }
 
     public void cancel(Long id, Member member) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,6 @@
 INSERT INTO member (name, email, password, role)
-VALUES ('어드민', 'admin@email.com', 'password', 'ADMIN'),
-       ('브라운', 'brown@email.com', 'password', 'USER');
+VALUES ('어드민', 'admin@email.com', '$2a$10$pTDaKfPeXcgbPbbbjh7vt.ddoFceJSlefp62mpFSExf/p.3H6.16G', 'ADMIN'),
+       ('브라운', 'brown@email.com', '$2a$10$pTDaKfPeXcgbPbbbjh7vt.ddoFceJSlefp62mpFSExf/p.3H6.16G', 'USER');
 
 INSERT INTO theme (name, description, deleted)
 VALUES ('테마1', '테마1입니다.', false),

--- a/src/test/java/roomescape/JpaTest.java
+++ b/src/test/java/roomescape/JpaTest.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
 import roomescape.model.Time;
 import roomescape.repository.TimeRepository;
 
 @DataJpaTest
-@Import(TimeRepository.class)
 public class JpaTest {
     @Autowired
     private TestEntityManager entityManager;


### PR DESCRIPTION
준수님 안녕하세요! 이번 Spring Data JPA 2차 미션 리뷰를 부탁드리게 된 하수한이라고합니다! 저번 미션때도 한번 뵐 기회가 있었던 것 같은데, 실질적으로는 이번이 처음인 것 같네요. 잘 부탁드립니다!!

이번 미션에서는 1차 미션에서 순수 JPA 기반으로 구현한 로직을 Spring Data JPA로 마이그레이션을 진행하였습니다.
확실히 기존에 비해 boilerplate 코드 양이 줄어들어 이점이 있을 것 같다는 생각이 들었습니다. 다만 복잡한 쿼리의 경우 인터페이스 내에 `@Query` 어노테이션을 통해 직접 작성해야 하는 부분이 있어 이 부분은 좀 아쉽다고 생각했습니다 ㅎㅎ..

다음은 현재 프로젝트 구조입니다:
```
auth/
- AdminRoute - 관리자 endpoint를 구분하기 위한 어노테이션
- AdminRouteInterceptor - AdminRoute 어노테이션 구현
- JwtTokenProvider - JWT 관련 유틸리티 메소드
- LoginMember - 쿠키로부터 사용자 객체를 불러오는 커스텀 ArgumentResolver 어노테이션
- LoginMemberArgumentResolver - LoginMember 어노테이션 구현
config/
- WebConfig - WebMvcConfigurer 구현체
controller/
- MemberController - 사용자 관련 endpoint 정의
- ReservationController - 예약 관련 endpoint 정의
- ThemeController - 테마 관련 endpoint 정의
- TimeController - 시간 관련 endpoint 정의
- ViewController - thymeleaf 템플릿 관련 endpoint 정의
- WaitingController - 예약 대기 관련 endpoint 정의
repository/
- MemberRepository - 사용자 관련 DB 로직 정의
- ReservationRepository - 예약 관련 DB 로직 정의
- ThemeRepository - 테마 관련 DB 로직 정의
- TimeRepository - 시간 관련 DB 로직 정의
- WaitingRepository - 예약 대기 관련 DB 로직 정의
dto/
- ...(계층 간 데이터 전송에 필요한 객체들 정의)
exception/
- BadRequestException - 잘못된 요청에 대한 커스텀 예외
- GlobalExceptionHandler - 공통 예외 처리 로직
- UnauthorizedException - 인증되지 않은 사용자에 대한 커스텀 예외
model/
- ...(DB 테이블 스키마 정의)
service/
- AuthService - 사용자 인증 관련 로직 정의
- MemberService - 사용자 관련 로직 정의
- ReservationService - 예약 관련 로직 정의
- TimeService - 시간 관련 로직 정의
- WaitingService - 예약 대기 관련 로직 정의
RoomescapeApplication - Main entrypoint
```

코드의 경우 Repository 레이어 쪽 변경 사항 말고는 거의 기존과 동일한 상태이기에 해당 부분 감안하여 봐주시면 감사하겠습니다!