### PR TITLE
[SCG] 손희창 방탈출예약 1-3단계 제출합니다.

### DIFF
--- a/src/main/java/roomescape/WebMvcConfig.java
+++ b/src/main/java/roomescape/WebMvcConfig.java
@@ -14,19 +14,21 @@ import roomescape.member.MemberService;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final MemberService memberService;
+    private final AdminInterceptor adminInterceptor;
 
-    public WebMvcConfig(MemberService memberService) {
+    public WebMvcConfig(MemberService memberService, AdminInterceptor adminInterceptor) {
         this.memberService = memberService;
+        this.adminInterceptor = adminInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver(memberService));
+        resolvers.add(new LoginMemberArgumentResolver(memberService, memberService.getSecretKey()));
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AdminInterceptor(memberService))
-                .addPathPatterns("/admin", "/admin/**");
+        registry.addInterceptor(adminInterceptor)
+                .addPathPatterns("/admin", "/admin/**", "/reservations", "/reservations/**");
     }
 }

--- a/src/main/java/roomescape/WebMvcConfig.java
+++ b/src/main/java/roomescape/WebMvcConfig.java
@@ -1,0 +1,32 @@
+package roomescape;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+import roomescape.member.AdminInterceptor;
+import roomescape.member.LoginMemberArgumentResolver;
+import roomescape.member.MemberService;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final MemberService memberService;
+
+    public WebMvcConfig(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(memberService));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminInterceptor(memberService))
+                .addPathPatterns("/admin", "/admin/**");
+    }
+}

--- a/src/main/java/roomescape/member/AdminInterceptor.java
+++ b/src/main/java/roomescape/member/AdminInterceptor.java
@@ -3,17 +3,19 @@ package roomescape.member;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
+@Component
 public class AdminInterceptor implements HandlerInterceptor {
 
-    private final MemberService memberService;
-    private static final String SECRET_KEY = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+    private final String secretKey;
 
-    public AdminInterceptor(MemberService memberService) {
-        this.memberService = memberService;
+    public AdminInterceptor(@Value("${jwt.secret}") String secretKey) {
+        this.secretKey = secretKey;
     }
 
     @Override
@@ -21,36 +23,51 @@ public class AdminInterceptor implements HandlerInterceptor {
         Cookie[] cookies = request.getCookies();
 
         try {
-            String token = extractToken(cookies);
+            String token = extractTokenFromCookie(cookies);
 
             String role = Jwts.parserBuilder() //그냥 토큰에서 Role정보를 빼오는 방식 DB 조회를 하지 않고
-                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
                     .build()
                     .parseClaimsJws(token)
                     .getBody()
                     .get("role", String.class);
 
-            if (role == null || !"ADMIN".equals(role)) {
-                response.setStatus(401);
-                return false;
+            if (role == null) {
+                throw new IllegalStateException("토큰 내 권한 정보(Role)가 존재하지 않습니다.");
+            }
+
+            String requestURI = request.getRequestURI();
+
+            if (requestURI.startsWith("/admin")) {
+                if (!"ADMIN".equals(role)) {
+                    response.setStatus(403);
+                    return false;
+                }
+                return true;
+            }
+
+            if (requestURI.startsWith("/reservations")) {
+                if ("ADMIN".equals(role) || "USER".equals(role)) {
+                    return true;
+                }
             }
 
             return true;
         } catch (Exception e) {
-            response.setStatus(401);
+            response.setStatus(401); //미인증
             return false;
         }
     }
 
-    private String extractToken(Cookie[] cookies) {
+    private String extractTokenFromCookie(Cookie[] cookies) {
         if (cookies == null) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("요청에 쿠키 배열이 존재하지 않습니다.");
         }
         for (Cookie cookie : cookies) {
             if ("token".equals(cookie.getName())) {
                 return cookie.getValue();
             }
         }
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("쿠키 중 인증 토큰('token')을 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/roomescape/member/AdminInterceptor.java
+++ b/src/main/java/roomescape/member/AdminInterceptor.java
@@ -1,0 +1,56 @@
+package roomescape.member;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+public class AdminInterceptor implements HandlerInterceptor {
+
+    private final MemberService memberService;
+    private static final String SECRET_KEY = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+
+    public AdminInterceptor(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Cookie[] cookies = request.getCookies();
+
+        try {
+            String token = extractToken(cookies);
+
+            String role = Jwts.parserBuilder() //그냥 토큰에서 Role정보를 빼오는 방식 DB 조회를 하지 않고
+                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .get("role", String.class);
+
+            if (role == null || !"ADMIN".equals(role)) {
+                response.setStatus(401);
+                return false;
+            }
+
+            return true;
+        } catch (Exception e) {
+            response.setStatus(401);
+            return false;
+        }
+    }
+
+    private String extractToken(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new IllegalArgumentException();
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/src/main/java/roomescape/member/LoginMember.java
+++ b/src/main/java/roomescape/member/LoginMember.java
@@ -1,0 +1,31 @@
+package roomescape.member;
+
+public class LoginMember {
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final String role;
+
+    public LoginMember(Long id, String name, String email, String role) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/member/LoginMemberArgumentResolver.java
@@ -1,5 +1,7 @@
 package roomescape.member;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -11,11 +13,12 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final MemberService memberService;
+    private final String secretKey;
 
-    public LoginMemberArgumentResolver(MemberService memberService) {
+    public LoginMemberArgumentResolver(MemberService memberService, String secretKey) {
         this.memberService = memberService;
+        this.secretKey = secretKey;
     }
-
     @Override
     public boolean supportsParameter(MethodParameter parameter) { //로그인한 회원정보의 필요여부 판단
         return parameter.getParameterType().equals(LoginMember.class);
@@ -31,11 +34,18 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
         MemberResponse memberResponse = memberService.findMemberByToken(token);
 
+        String role = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+
         return new LoginMember(
                 memberResponse.getId(),
                 memberResponse.getName(),
                 memberResponse.getEmail(),
-                "USER"
+                role
         );
     }
 

--- a/src/main/java/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/member/LoginMemberArgumentResolver.java
@@ -1,0 +1,53 @@
+package roomescape.member;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+
+    public LoginMemberArgumentResolver(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) { //로그인한 회원정보의 필요여부 판단
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Cookie[] cookies = request.getCookies();
+
+        String token = extractTokenFromCookie(cookies);
+
+        MemberResponse memberResponse = memberService.findMemberByToken(token);
+
+        return new LoginMember(
+                memberResponse.getId(),
+                memberResponse.getName(),
+                memberResponse.getEmail(),
+                "USER"
+        );
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new IllegalArgumentException("쿠키가 존재하지 않아 인증할 수 없습니다.");
+        }
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        throw new IllegalArgumentException("인증 토큰(token) 쿠키를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -25,6 +25,28 @@ public class MemberController {
         return ResponseEntity.created(URI.create("/members/" + member.getId())).body(member);
     }
 
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody MemberRequest memberRequest, HttpServletResponse response) {
+        String token = memberService.createToken(memberRequest.getEmail(), memberRequest.getPassword());
+
+        Cookie cookie = new Cookie("token", token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String token = extractTokenFromCookie(cookies);
+
+        MemberResponse memberResponse = memberService.findMemberByToken(token);
+
+        return ResponseEntity.ok().body(memberResponse);
+    }
+
     @PostMapping("/logout")
     public ResponseEntity logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("token", "");
@@ -33,5 +55,15 @@ public class MemberController {
         cookie.setMaxAge(0);
         response.addCookie(cookie);
         return ResponseEntity.ok().build();
+    }
+
+    private String extractTokenFromCookie(Cookie[] cookies) {
+        if (cookies == null) return "";
+        for (Cookie cookie : cookies) {
+            if ("token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
     }
 }

--- a/src/main/java/roomescape/member/MemberController.java
+++ b/src/main/java/roomescape/member/MemberController.java
@@ -58,7 +58,7 @@ public class MemberController {
     }
 
     private String extractTokenFromCookie(Cookie[] cookies) {
-        if (cookies == null) return "";
+        if (cookies == null) return ""; //빈 값은 빈 값대로 로그인 안했을 시
         for (Cookie cookie : cookies) {
             if ("token".equals(cookie.getName())) {
                 return cookie.getValue();

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,9 +1,13 @@
 package roomescape.member;
 
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MemberService {
+    private static final String SECRET_KEY = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
     private MemberDao memberDao;
 
     public MemberService(MemberDao memberDao) {
@@ -13,5 +17,41 @@ public class MemberService {
     public MemberResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+    }
+
+    public String createToken(String email, String password) {
+        try {
+            Member member = memberDao.findByEmailAndPassword(email, password);
+
+            return Jwts.builder()
+                    .setSubject(member.getId().toString())
+                    .claim("name", member.getName())
+                    .claim("role", member.getRole())
+                    .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .compact();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+    }
+
+    public MemberResponse findMemberByToken(String token) {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 존재하지 않습니다.");
+        }
+
+        try {
+            String name = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .get("name", String.class);
+
+            Member member = memberDao.findByName(name);
+
+            return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 토큰이거나 인증에 실패했습니다.");
+        }
     }
 }

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -1,6 +1,5 @@
 package roomescape.member;
 
-
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/roomescape/member/MemberService.java
+++ b/src/main/java/roomescape/member/MemberService.java
@@ -3,15 +3,25 @@ package roomescape.member;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import java.util.Date;
 
 @Service
 public class MemberService {
-    private static final String SECRET_KEY = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+
+    private final String secretKey;
     private MemberDao memberDao;
 
-    public MemberService(MemberDao memberDao) {
+    private static final long TOKEN_VALIDITY_IN_MILLISECONDS = 3600000;
+
+    public MemberService(MemberDao memberDao, @Value("${jwt.secret}") String secretKey) {
         this.memberDao = memberDao;
+        this.secretKey = secretKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
     }
 
     public MemberResponse createMember(MemberRequest memberRequest) {
@@ -23,11 +33,16 @@ public class MemberService {
         try {
             Member member = memberDao.findByEmailAndPassword(email, password);
 
+            Date now = new Date();
+            Date validity = new Date(now.getTime() + TOKEN_VALIDITY_IN_MILLISECONDS);
+
             return Jwts.builder()
                     .setSubject(member.getId().toString())
                     .claim("name", member.getName())
                     .claim("role", member.getRole())
-                    .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .setIssuedAt(now)
+                    .setExpiration(validity)
+                    .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                     .compact();
         } catch (Exception e) {
             throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
@@ -41,7 +56,7 @@ public class MemberService {
 
         try {
             String name = Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
                     .build()
                     .parseClaimsJws(token)
                     .getBody()

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -40,8 +40,8 @@ public class ReservationController {
     }
 
     @DeleteMapping("/reservations/{id}")
-    public ResponseEntity delete(@PathVariable Long id) {
-        reservationService.deleteById(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, LoginMember loginMember) {
+        reservationService.deleteById(id, loginMember);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/reservation/ReservationController.java
+++ b/src/main/java/roomescape/reservation/ReservationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.util.List;
+import roomescape.member.LoginMember;
 
 @RestController
 public class ReservationController {
@@ -26,14 +27,14 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember loginMember) {
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
         }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+
+        ReservationResponse reservation = reservationService.save(reservationRequest, loginMember);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/roomescape/reservation/ReservationDao.java
@@ -43,12 +43,12 @@ public class ReservationDao {
                         )));
     }
 
-    public Reservation save(ReservationRequest reservationRequest) {
+    public Reservation save(ReservationRequest reservationRequest, String name) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
             ps.setString(1, reservationRequest.getDate());
-            ps.setString(2, reservationRequest.getName());
+            ps.setString(2, name);
             ps.setLong(3, reservationRequest.getTheme());
             ps.setLong(4, reservationRequest.getTime());
             return ps;
@@ -64,7 +64,7 @@ public class ReservationDao {
 
         return new Reservation(
                 keyHolder.getKey().longValue(),
-                reservationRequest.getName(),
+                name,
                 reservationRequest.getDate(),
                 time,
                 theme

--- a/src/main/java/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/roomescape/reservation/ReservationDao.java
@@ -43,6 +43,31 @@ public class ReservationDao {
                         )));
     }
 
+    public Reservation findById(Long id) {
+        return jdbcTemplate.queryForObject(
+                "SELECT r.id AS reservation_id, r.name as reservation_name, r.date as reservation_date, " +
+                        "t.id AS theme_id, t.name AS theme_name, t.description AS theme_description, " +
+                        "ti.id AS time_id, ti.time_value AS time_value " +
+                        "FROM reservation r " +
+                        "JOIN theme t ON r.theme_id = t.id " +
+                        "JOIN time ti ON r.time_id = ti.id " +
+                        "WHERE r.id = ?",
+                (rs, rowNum) -> new Reservation(
+                        rs.getLong("reservation_id"),
+                        rs.getString("reservation_name"),
+                        rs.getString("reservation_date"),
+                        new Time(
+                                rs.getLong("time_id"),
+                                rs.getString("time_value")
+                        ),
+                        new Theme(
+                                rs.getLong("theme_id"),
+                                rs.getString("theme_name"),
+                                rs.getString("theme_description")
+                        )),
+                id);
+    }
+
     public Reservation save(ReservationRequest reservationRequest, String name) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
@@ -82,7 +107,7 @@ public class ReservationDao {
                         "ti.id AS time_id, ti.time_value AS time_value " +
                         "FROM reservation r " +
                         "JOIN theme t ON r.theme_id = t.id " +
-                        "JOIN time ti ON r.time_id = ti.id" +
+                        "JOIN time ti ON r.time_id = ti.id " +
                         "WHERE r.date = ? AND r.theme_id = ?",
                 new Object[]{date, themeId},
                 (rs, rowNum) -> new Reservation(

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -3,6 +3,7 @@ package roomescape.reservation;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import roomescape.member.LoginMember;
 
 @Service
 public class ReservationService {
@@ -12,10 +13,20 @@ public class ReservationService {
         this.reservationDao = reservationDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        String reservationName;
+        if (reservationRequest.getName() != null && !reservationRequest.getName().isBlank()) {
+            reservationName = reservationRequest.getName();
+        } else {
+            if (loginMember == null) {
+                throw new IllegalArgumentException("로그인 정보가 없거나 예약자 이름이 비어있습니다.");
+            }
+            reservationName = loginMember.getName();
+        }
+        Reservation reservation = reservationDao.save(reservationRequest, reservationName);
+
+        return new ReservationResponse(reservation.getId(), reservationName, reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/roomescape/reservation/ReservationService.java
+++ b/src/main/java/roomescape/reservation/ReservationService.java
@@ -1,7 +1,6 @@
 package roomescape.reservation;
 
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import roomescape.member.LoginMember;
 
@@ -14,7 +13,6 @@ public class ReservationService {
     }
 
     public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
-
         String reservationName;
         if (reservationRequest.getName() != null && !reservationRequest.getName().isBlank()) {
             reservationName = reservationRequest.getName();
@@ -29,7 +27,17 @@ public class ReservationService {
         return new ReservationResponse(reservation.getId(), reservationName, reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
     }
 
-    public void deleteById(Long id) {
+    public void deleteById(Long id, LoginMember loginMember) {
+        if (loginMember == null) {
+            throw new IllegalArgumentException("로그인 정보가 없습니다.");
+        }
+
+        Reservation reservation = reservationDao.findById(id);
+
+        if (!"ADMIN".equals(loginMember.getRole()) && !reservation.getName().equals(loginMember.getName())) {
+            throw new IllegalArgumentException("본인의 예약만 삭제할 수 있습니다.");
+        }
+
         reservationDao.deleteById(id);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.sql.init.encoding=utf-8
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.datasource.url=jdbc:h2:mem:database
+jwt.secret=Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
 
 #spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -4,7 +4,9 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -101,5 +103,28 @@ public class MissionStepTest {
                 .get("/admin")
                 .then().log().all()
                 .statusCode(200);
+    }
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private String createExpiredToken() {
+        Date past = new Date(System.currentTimeMillis() - 60000);
+        return io.jsonwebtoken.Jwts.builder()
+                .setSubject("1")
+                .claim("name", "브라운")
+                .claim("role", "USER")
+                .setIssuedAt(past)
+                .setExpiration(past)
+                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+    }
+    @Test
+    void 토큰_만료_테스트() {
+        String expiredToken = createExpiredToken();
+        RestAssured.given().log().all()
+                .cookie("token", expiredToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import roomescape.reservation.ReservationResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,5 +35,71 @@ public class MissionStepTest {
         String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
 
         assertThat(token).isNotBlank();
+    }
+    @Test
+    void 이단계() {
+        String token = createToken("admin@email.com", "password");  // 일단계에서 토큰을 추출하는 로직을 메서드로 따로 만들어서 활용하세요.
+
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-03-01");
+        params.put("time", "1");
+        params.put("theme", "1");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        assertThat(response.as(ReservationResponse.class).getName()).isEqualTo("어드민");
+
+        params.put("name", "브라운");
+
+        ExtractableResponse<Response> adminResponse = RestAssured.given().log().all()
+                .body(params)
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .post("/reservations")
+                .then().log().all()
+                .extract();
+
+        assertThat(adminResponse.statusCode()).isEqualTo(201);
+        assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+    }
+    private String createToken(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/login")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        return response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
+    }
+    @Test
+    void 삼단계() {
+        String brownToken = createToken("brown@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        String adminToken = createToken("admin@email.com", "password");
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -92,7 +92,7 @@ public class MissionStepTest {
                 .cookie("token", brownToken)
                 .get("/admin")
                 .then().log().all()
-                .statusCode(401);
+                .statusCode(403);
 
         String adminToken = createToken("admin@email.com", "password");
 


### PR DESCRIPTION
안녕하세요!
노베에서 Spring을 배워가고 있습니다.

현재 ReservationRequest에서 Setter를 안쓰기 위해, 서비스 레이어에서 조건문으로 reservationName을 결정한 뒤 Dao 파라미터로 넘겨주는 방식을 선택했습니다. 혹시 서비스 레이어가 아니라 ReservationRequest 내부에 새로운 형식의 객체를 만드는 메서드를 넣어 기존 예약 데이터에 String newname을 포함한 새로운 객체를 만드는 메서드를 넣는 방식도 괜찮은 구조일지 궁금합니다.

그리고 3단계 구현(Intercept)에서 힌트 코드 구조는 
```
@Override
    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
    
        ...
        
        if (member == null || !member.getRole().equals("ADMIN")) {
            response.setStatus(401);
            return false;
        }

        return true;
```
이거였는데 사실 이 코드에서는 ...에 MemberResponse member = memberService.findMemberByToken(token);가 들어갈 텐데
그러면 findMemberByToken메서드 안에 Member member = memberDao.findByName(name);에서 DB를 다시 조회하게 되는데
사실 토큰을 만들때.claim("role", member.getRole()) 롤도 같이 넣어줘서 힌트 코드 구조를 조금 벗어나게 토큰 자체에서 Jwts를 활용해 Role만 꺼내오는 방식으로 코드를 짜봤습니다.
```
 try {
            String token = extractToken(cookies);

            String role = Jwts.parserBuilder() //그냥 토큰에서 Role정보를 빼오는 방식 DB 조회를 하지 않고
                    .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
                    .build()
                    .parseClaimsJws(token)
                    .getBody()
                    .get("role", String.class);

            if (role == null || !"ADMIN".equals(role)) {
                response.setStatus(401);
                return false;
            }

            return true;
        } catch (Exception e) {
            response.setStatus(401);
            return false;
        }
        //AdminInterceptor.js 
```
혹시 힌트 코드 구조가 원래 요구하는건 토큰을 식별자로 해서 DB를 다시 조회해서 Role을 가져오는 방식이 맞을까요?
제 방식에는 문제점이 있을까요?
잘못되거나 개선되어야할 코드가 있다면 꼭 말씀주시면 감사하겠습니다.
수~금까지는 여행일정이 있어서 토요일에 리뷰 확인하고 리뷰 반영하겠습니다!
잘부탁드립니다!